### PR TITLE
Removed Section formerly 5.D.2.A.4.C, Alternate Housing, which violates RIT housing

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -581,7 +581,6 @@ Any of these requirements may be waived by the Evaluations Director or a simple 
 \begin{enumerate}
 	\item Introductory Members may be offered Active Membership (\ref{Active Membership}) provided they meet the requirements described in \ref{Expectations of an Introductory Member}, at the discretion of House.
 	\item If an Introductory Member fails to meet the requirements, their membership will be revoked.
-		In addition, the participant is asked to find alternative housing as soon as possible in accordance with all applicable Residence Life policies regarding room changes.
 	\item An Introductory member may be given a conditional to complete as a means of making up for missing requirements.
 		A conditional may be proposed by any member present at the Introductory Evaluation and, if it is approved by the Evaluations Director, is then voted on by House.
 		Each conditional consists of a set of additional requirements and a deadline for completing them.
@@ -994,10 +993,6 @@ An option in the vote passes if the number of votes cast for the option equals o
 \asubsection{Three-Quarters}
 In a Three-Quarters Vote, a Quorum is reached if the Total Number of Votes Cast is equal to or exceeds three-quarters the Total Number of Possible Votes.
 An option in the vote passes if the number of votes cast for the option equals or exceeds three-quarters of the Total Number of Votes Cast.
-\asubsection{Three Tiered}
-When voting on a set of three choices where each choice can be ranked in a definite order, a selection for either the lowest or highest option will only pass if the votes cast for that selection exceed fifty percent of the Total Number of Votes Cast.
-If neither the highest or lowest selection exceeds fifty percent, the middle option will then automatically be passed.
-In a Three-Tiered Vote, a Quorum is reached if the Total Number of Votes Cast is equal to or exceeds two-thirds of the Total Number of Possible Votes.
 
 \asubsection{Alternative}
 The winning option is selected outright if it gains more than half the votes cast as a first preference.

--- a/constitution.tex
+++ b/constitution.tex
@@ -993,7 +993,10 @@ An option in the vote passes if the number of votes cast for the option equals o
 \asubsection{Three-Quarters}
 In a Three-Quarters Vote, a Quorum is reached if the Total Number of Votes Cast is equal to or exceeds three-quarters the Total Number of Possible Votes.
 An option in the vote passes if the number of votes cast for the option equals or exceeds three-quarters of the Total Number of Votes Cast.
-
+\asubsection{Three Tiered}
+When voting on a set of three choices where each choice can be ranked in a definite order, a selection for either the lowest or highest option will only pass if the votes cast for that selection exceed fifty percent of the Total Number of Votes Cast.
+If neither the highest or lowest selection exceeds fifty percent, the middle option will then automatically be passed.
+In a Three-Tiered Vote, a Quorum is reached if the Total Number of Votes Cast is equal to or exceeds two-thirds of the Total Number of Possible Votes.
 \asubsection{Alternative}
 The winning option is selected outright if it gains more than half the votes cast as a first preference.
 If not, the option with the fewest number of first preference votes is eliminated and their votes move to the second preference marked on the ballot papers.


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Section formerly 5.D.2.A.4.C, Alternate Housing, is removed to reflect current practice and comply with RIT Housing, which resolves #2.
