### PR TITLE
Resolve #22 Combine Honorary and Advisory Members

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -246,43 +246,37 @@ Alumni Members are not subject to any evaluation.
 There are no resignations associated with Alumni Membership status.
 \asubsection{Alumni Membership Term}
 Alumni Membership shall last indefinitely or until the member chooses to pursue Active Membership.
-
-\asection{Honorary Membership}
+\asection{Honorary and Advisory Memberships}
 \asubsection{Honorary Membership Qualifications}
 Honorary Membership is open to a person whom the House feels has contributed great personal effort to the House and is deserving of House recognition.
-\asubsection{Honorary Membership Selection}
-Any House member may nominate a candidate for Honorary Membership by submitting the name in writing to the Evaluations Director.
-The Evaluation Director then begins the Honorary Membership Selection Process as defined in \ref{Selection Process for Honorary Members}
-\asubsection{Honorary Membership Expectations}
-Honorary Members are encouraged to remain in contact with the House.
-\asubsection{Honorary Membership Privileges}
-Honorary Members may advise in all issues brought before the House, use Computer Science House facilities, and attend Computer Science House functions.
-\asubsection{Honorary Membership Evaluations}
-Honorary Members are not subject to formal evaluations.
-\asubsection{Honorary Membership Resignations}
-An Honorary Member may resign by submitting in writing the reason for resignation to the Chairperson.
-The resignation will be read at the following House Meeting and become effective at that time.
-\asubsection{Honorary Membership Term}
-Honorary Membership shall last until the member resigns.
-
-\asection{Advisory Membership}
 \asubsection{Advisory Membership Qualifications}
 Advisory Membership is open to all members of the Rochester Institute of Technology professional, academic, or administrative staff.
-\asubsection{Advisory Membership Selection}
-The Executive Board may open nominations for Advisory Members.
-The candidates then participate in the Advisory Selection Process as defined in \ref{Selection Process for Advisory Members}
+\asubsection{Honorary and Advisory Membership Selection}
+\begin{enumerate}
+	\item A House Member submits to the Evaluations Director a nomination, in writing, for a person they feel is deserving of Honorary or Advisory Membership. The nomination must specify the type of membership the nominee is nominated for.
+	\item The Evaluations Director performs preliminary research on the candidate and presents the findings.
+	\item The Executive Board decides whether or not to present the nomination to the House for a secret ballot House vote.
+		If the Executive Board decides not to present the nomination to the House, the Selection Process ends and the candidate does not become a Member.
+	\item The nomination is presented at a House Meeting for discussion and a Two-Thirds vote, as defined in \ref{Two-Thirds}.
+		Ballots are distributed and voting must remain open for a minimum of forty-eight hour period.
+	\item Candidates selected for Honorary Membership are notified of their selection as an Honorary Member and presented with the honor.
+    \item Candidates selected for Advisory Membership are notified of their acceptance as House Advisors and asked to accept or decline
+        the selection.
+\end{enumerate}
+\asubsection{Honorary Membership Expectations}
+Honorary Members are encouraged to remain in contact with the House.
 \asubsection{Advisory Membership Expectations}
 Advisors are encouraged to offer advice and assistance to the House in any capacity the Advisor is able to help.
-Advisors are also encouraged to meet the House members and occasionally attend House activities.
-\asubsection{Advisory Membership Privileges}
-Advisory Members may advise in all issues brought before the House, use Computer Science House facilities, and attend Computer Science House functions.
-\asubsection{Advisory Membership Evaluations}
-Advisors are not subject to formal evaluations.
-\asubsection{Advisory Membership Resignations}
-An Advisor may resign by submitting in writing the reason for resignation to the Chairperson.
+Advisors are also encouraged to meet House members and occasionally attend House activities.
+\asubsection{Honorary and Advisory Membership Privileges}
+Honorary and Advisory Members may advise in all issues brought before the House, use Computer Science House facilities, and attend Computer Science House functions.
+\asubsection{Honorary and Advisory Membership Evaluations}
+Honorary and Advisory Members are not subject to formal evaluations.
+\asubsection{Honorary and Advisory Membership Resignations}
+An Honorary or Advisory Member may resign by submitting in writing the reason for resignation to the Chairperson.
 The resignation will be read at the following House Meeting and become effective at that time.
-\asubsection{Advisory Membership Term}
-Advisory Membership shall last until the member resigns.
+\asubsection{Honorary and Advisory Membership Term}
+Honorary and Advisory Memberships shall last until the member resigns.
 
 \asection{Leave of Absence}
 A leave of absence offers the option for members to take extended time away from their responsibilities to House for any number of personal issues including, but not limited to, physical illness, mental illness, or care giving for a sick family member.


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Intended to supplement discussion on combining Honorary and Advisory Memberships.

Summary of change(s):

- Both Honorary and Advisory members are selected via 2/3 votes
- Honorary and Advisory Members share the selection, priveleges, evaluations, resignations, and term 
subsections.