### PR TITLE
Resolve #11 Quorum Definition Unnecessarily Broad

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -915,7 +915,7 @@ If the vote passes, the Executive Board may discuss and make a new ruling by ano
 This section outlines the different types of votes and ballots used to make House decisions and defines relevant terminology.
 \asection{Definitions}
 \asubsection{Total Number of Possible Votes}
-The sum of the number of Active members eligible to vote (i.e. not on co-op)
+The sum of the number of Active members eligible to vote on the issue.
 \asubsection{Total Number of Votes Cast}
 The Total Number of Votes Cast is defined as the total number of votes received for every voting option minus the number of abstentions.
 \asubsection{Quorum}


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Replaced parenthetical with slightly less ambiguous language to resolve #11.
