### PR TITLE
Resolve #7 Fix Financial Information/Calculations in 5.D.1.C

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -505,7 +505,11 @@ Accumulated & 5\% \\
 \end{tabular}
 \end{center}
 
-Dues collected from on-floor members are to be distributed into directorship budgets as shown in the above table. Money allocated for Accumulated and money collected from off-floor members is deposited into the CSH Account and saved.
+% The suggested total operating budget is $8360.
+% This figure comes from having approximately 55 on-floor members with $80 per semester dues (totaling $8800) minus 5% set aside for Accumulated.
+
+Dues collected from on-floor members are to be distributed into directorship budgets as shown in the above table.
+Money allocated for Accumulated or collected from off-floor members is deposited into the CSH Account and saved.
 
 \asubsubsection{Expenditure Approval}
 All House expenditures must be approved by both the Financial Director and the appropriate Director (from whose budget the funds will be drawn).

--- a/constitution.tex
+++ b/constitution.tex
@@ -488,7 +488,7 @@ Directorship Name & Percentage of Dues \\
 \hline
 Operational Communications & 20\% \\
 \hline
-Evaluations \& Selections & 5\% \\
+Evaluations & 5\% \\
 \hline
 House History & 10\% \\
 \hline
@@ -505,9 +505,7 @@ Accumulated & 5\% \\
 \end{tabular}
 \end{center}
 
-The suggested total operational budget is \$8064.
-This figure is based on yearly estimated on-floor member dues (\$160 x 72 members = \$11520) minus the 10\% reserved for Accumulated (Accum).
-Money allocated for Accum and off-floor member dues is deposited into the CSH Account and saved.
+Dues collected from on-floor members are to be distributed into directorship budgets as shown in the above table. Money allocated for Accumulated and money collected from off-floor members is deposited into the CSH Account and saved.
 
 \asubsubsection{Expenditure Approval}
 All House expenditures must be approved by both the Financial Director and the appropriate Director (from whose budget the funds will be drawn).


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
This PR proposes a change to 5.D.1.C, namely by removing all calculations and clarifying where dues from on-floor and off-floor members go.