### PR TITLE
Resolve #36 Membership Evaluations Only Occur Once A Year

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -375,7 +375,7 @@ However, the Chairperson and at least two-thirds of the Voting Members of the Ex
 	\item To preside over Evaluations Meetings
 	\item To exercise general supervision over Evaluations operations
 	\item To oversee the screening, interviewing, and acceptance or rejection of prospective House members
-	\item To oversee the Membership Evaluations of current House Members
+	\item To oversee the Membership Evaluations of Active Members
 	\item To collaborate with the Residence Life Advisor to determine room change selection and any changes of membership residency
 	\item To act as a part of a Judicial Board as defined in \ref{Judicial}
 	\item To prepare the House for Open Houses, tours, and special events

--- a/constitution.tex
+++ b/constitution.tex
@@ -375,7 +375,7 @@ However, the Chairperson and at least two-thirds of the Voting Members of the Ex
 	\item To preside over Evaluations Meetings
 	\item To exercise general supervision over Evaluations operations
 	\item To oversee the screening, interviewing, and acceptance or rejection of prospective House members
-	\item To oversee the Semi-Annual Evaluations of current House members
+	\item To oversee the Membership Evaluations of current House Members
 	\item To collaborate with the Residence Life Advisor to determine room change selection and any changes of membership residency
 	\item To act as a part of a Judicial Board as defined in \ref{Judicial}
 	\item To prepare the House for Open Houses, tours, and special events
@@ -640,8 +640,7 @@ Additional Note: No hazing shall occur at any time during the Selection Process 
 \asubsubsection{Evaluations Processes}
 During the academic year, a House member is evaluated by the Membership Evaluation.
 The Membership Evaluation is responsible for determining those individuals who will have the option to continue Active Membership in the following year.
-Semi-Annual Evaluations Meetings are open only to current Active Members.
-All Executive Board members are expected to attend the Semi-Annual Evaluations Meetings to assist in the evaluations of House members.
+All Executive Board members are expected to attend the Membership Evaluation to assist in the evaluations of House Members.
 \\* \\*
 At the beginning of any Evaluation Process listed herein, the Evaluations Director must read the sections of the Computer Science House Constitution used during the respective Evaluation Process.
 It is incumbent upon each House member to provide the Evaluation Director with whatever information they feel is necessary to ensure an accurate evaluation.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Resolves issue #36 by replacing both references to Semi-Annual Membership Evaluations found in 5.C.3(d) and 5.D.2.C.
