### PR TITLE
Resolve #49 Full Membership

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -607,8 +607,9 @@ Additional Note: No hazing shall occur at any time during the Selection Process 
 \begin{enumerate}
 	\item During Spring semester, the Evaluations Director selects a group of Active Members to form a Selections Committee.
 		The Selections Committee reviews applications and conducts interviews in accordance with the process prescribed by Residence Life.
-	\item A subset of applications will be selected to move onto the House Fall Semester, are granted full membership privileges (including On-Floor status), and must participate in the Introductory Process as defined in \ref{The Introductory Process}.
-		An additional subset will be given Off-Floor status, but otherwise receive the same privileges and responsibilities.
+        \item A subset of applicants will be offered Introductory Membership and must participate in the Introductory Process defined in \ref{The Introductory Process}. 
+            A subset of Introductory Members will be offered On-Floor status and will be able to select a room on floor. 
+            The other Introductory Members will have Off-Floor status, but will otherwise have the same privileges and responsibilities.
 \end{enumerate}
 Note: Most membership privileges do not initiate until successful completion of the introductory process.
 This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.

--- a/constitution.tex
+++ b/constitution.tex
@@ -557,8 +557,8 @@ Before the end of the Process, an Introductory Member is expected to:
 \end{itemize}
 
 \asubsubsubsection{Introductory Evaluation}
-The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of full Resident or Non-Resident Membership.
-Occurs at the conclusion of the final week of the Process.
+The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of Active Membership.
+It occurs at the conclusion of the final week of the Process.
 
 \asubsubsubsubsection{Voting}
 On a member by member basis, this evaluation process determines if each Introductory member has successfully completed the Introductory Process requirements \ref{Expectations of an Introductory Member}.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Removed reference to full membership in 5.D.2.B.2 subsection (b)