### PR TITLE
Resolve #29 Alumni Housing Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ Installing dependencies on debian
 
 `sudo apt install texlive texlive-formats-extra make`
 
-Installing depencdencies on fedora
+Installing dependencies on fedora
 
 `sudo yum install texlive make`
 
 
 ## Compiling the Constitution
 Once required software is installed, simply run `make`.
-Running `make` will build and link the bylaws and articles properly.  
+Running `make` will build and link the articles properly.
 Review the PDF output to check for any errors before making a pull request.
 If additional commits are made, be sure to [rebase](https://git-scm.com/docs/git-rebase) down to one commit before submitting a pull request.
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -193,7 +193,7 @@ If the vote passes the Alumni is reinstated as an Active Member with Off-Floor s
 \asubsection{Active Membership Expectations}
 Active members are expected to be active participants in the House as defined in \ref{Expectations of House Members}.
 \asubsection{Active Membership Privileges}
-Active Members receive the right to:
+Active Members receive the privilege to:
 \begin{itemize}
 	\item Vote on all issues brought before the House
 	\item Reside on the House

--- a/constitution.tex
+++ b/constitution.tex
@@ -336,10 +336,6 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item House Secretary
 	\item Ad Hoc Director(s)
 \end{itemize}
-\asection{Closed Executive Board}
-Closed Executive Board Meetings are open only to the Chairperson, Voting Members of the Executive Board, and those with the express permission of the Executive Board.
-A closed Executive Board meeting may be called at any time by any member of the Executive Board.
-However, the Chairperson and at least two-thirds of the Voting Members of the Executive Board must be present for the meeting to be called.
 
 \asection{Responsibilities}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
@@ -456,6 +452,11 @@ However, the Chairperson and at least two-thirds of the Voting Members of the Ex
 	\item Ad Hoc Directorships are responsible for the task for which they were created
 	\item Any responsibilities budgets or finances for the Ad Hoc Directorship are placed upon the assigned director
 \end{enumerate}
+
+\asection{Closed Executive Board}
+Closed Executive Board Meetings are open only to the Chairperson, Voting Members of the Executive Board, and those with the express permission of the Executive Board.
+A closed Executive Board meeting may be called at any time by any member of the Executive Board.
+However, the Chairperson and at least two-thirds of the Voting Members of the Executive Board must be present for the meeting to be called.
 
 \asection{Operations}
 \asubsection{Operations of the Financial Directorship}

--- a/constitution.tex
+++ b/constitution.tex
@@ -220,7 +220,7 @@ An Active member may resign by submitting, in writing, the reason for resignatio
 Instead of forfeiting membership, Active members who resign may elect to become Alumni defined in \ref{Alumni Membership Selection}.
 The resignation will take effect immediately and an announcement will be made at the following House Meeting.
 \asubsection{Active Membership Term}
-Active Membership shall last until the member: resigns or changes membership status.
+Active Membership shall last until the member resigns or changes membership status.
 
 \asection{Alumni Membership}
 \asubsection{Alumni Membership Qualifications}

--- a/constitution.tex
+++ b/constitution.tex
@@ -676,7 +676,7 @@ However, it is to be understood in advance by the member that this option requir
 This participation will be evaluated by the Executive Board.
 
 \asubsubsection{Housing Status}
-All Active and Introductory Members have a housing status.
+All Alumni, Active, and Introductory Members have a housing status.
 This status indicates their right to priority housing on the floor.
 Alumni Members in good standing keep the housing status they had as Active Members.
 Alumni Members in bad standing have Off-Floor status.

--- a/constitution.tex
+++ b/constitution.tex
@@ -90,9 +90,6 @@ The objectives of Computer Science House are:
 % ARTICLE II - CONSTITUTIONAL STRUCTURE
 \article{Constitutional Structure}
 
-\asection{House Charter}
-The House Charter is a document drafted by the department of Residence Life, setting down the guidelines within which this House operates and from which it derives its authority.
-
 \asection{Constitution}
 The House Constitution is written and maintained by the House and defines the major aspects, goals, and governing structure of the house.
 It is reviewed annually by the Department of Residence Life.

--- a/constitution.tex
+++ b/constitution.tex
@@ -73,7 +73,7 @@
 \article{Introduction}
 
 \asection{Name}
-The name of this Special Interest House shall be Computer Science House.
+The name of this Special Interest House is Computer Science House.
 
 \asection{Derivation of Authority}
 The Computer Science House shall recognize that it receives its right to function as a Special Interest House from the Center for Residence Life.

--- a/constitution.tex
+++ b/constitution.tex
@@ -92,7 +92,6 @@ The objectives of Computer Science House are:
 
 \asection{Constitution}
 The House Constitution is written and maintained by the House and defines the major aspects, goals, and governing structure of the house.
-It is reviewed annually by the Department of Residence Life.
 
 \asubsection{Non-Semantic Changes}
 There are two methods for non-semantic change to the Constitution.

--- a/constitution.tex
+++ b/constitution.tex
@@ -181,7 +181,7 @@ Introductory membership shall last until the end of the introductory process, at
 \asubsection{Active Membership Qualifications}
 Active Membership is open to all students currently enrolled at the Rochester Institute of Technology who have passed the Introductory Evaluation and their most recent Membership Evaluation.
 \asubsection{Active Membership Selection}
-Alumni Members in good standing may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director. They will retain their previous On-Floor Status if applicable.
+Alumni Members in good standing may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director. They will retain their previous Housing Status if applicable.
 \\*\\*
 Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evaluations Director of their intent to participate, who will bring them up for a Simple Majority vote at the next House meeting.
 If the vote passes the Alumni is reinstated as an Active Member effective immediately.

--- a/constitution.tex
+++ b/constitution.tex
@@ -186,7 +186,7 @@ Introductory membership shall last until the end of the introductory process, at
 \asubsection{Active Membership Qualifications}
 Active Membership is open to all students currently enrolled at the Rochester Institute of Technology who have passed the Introductory Evaluation and their most recent Membership Evaluation.
 \asubsection{Active Membership Selection}
-Qualifying members may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director.
+Alumni Members in good standing may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director.
 \\*\\*
 Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evaluations Director of their intent to participate, who will bring them up for a Simple Majority vote at the next House meeting.
 If the vote passes the Alumni is reinstated as an Active Member with Off-Floor status effective immediately.

--- a/constitution.tex
+++ b/constitution.tex
@@ -184,7 +184,7 @@ Active Membership is open to all students currently enrolled at the Rochester In
 Alumni Members in good standing may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director.
 \\*\\*
 Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evaluations Director of their intent to participate, who will bring them up for a Simple Majority vote at the next House meeting.
-If the vote passes the Alumni is reinstated as an Active Member with Off-Floor status effective immediately.
+If the vote passes the Alumni is reinstated as an Active Member effective immediately.
 \asubsection{Active Membership Expectations}
 Active members are expected to be active participants in the House as defined in \ref{Expectations of House Members}.
 \asubsection{Active Membership Privileges}
@@ -678,7 +678,8 @@ This participation will be evaluated by the Executive Board.
 \asubsubsection{Housing Status}
 All Active and Introductory Members have a housing status.
 This status indicates their right to priority housing on the floor.
-Any Alumni Member in good standing will maintain their previous On Floor status upon a return to Active membership.
+Alumni Members in good standing keep the housing status they had as Active Members.
+Alumni Members in bad standing have Off-Floor status.
 \asubsubsubsection{On-Floor Status}
 Members with On-Floor status are eligible to live on the floor.
 To be granted On-Floor status, members may notify the Evaluations Director that they would like to come up for a vote.

--- a/constitution.tex
+++ b/constitution.tex
@@ -142,7 +142,7 @@ The Executive Board may choose to approve or reject the nomination by Simple Maj
 % ARTICLE III - GENERAL OPERATIONS OF THE HOUSE
 \article{General Operations of the House}
 \asection{Standard Operating Session}
-The Standard Operating Session for Computer Science House is during the twenty-eight weeks of Fall and Spring semesters.
+The Standard Operating Session for Computer Science House is during the Fall and Spring semesters.
 The Summer Sessions, Intersessions, Institute breaks, and all end of Semester Exam Weeks are considered non-standard operating sessions.
 Unless explicitly stated otherwise, the requirements and expectations defined in the constitution are for the Standard Operating Session.
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -130,11 +130,9 @@ Maintainers are expected to:
 \end{itemize}
 Failure to meet any of these expectations is grounds for revocation of Maintainer status by the Executive Board.
 
-\asubsection{Maintainer Resignations}
-Maintainers may resign at any time by notifying the current Executive Board and Maintainer group.
-
 \asubsection{Maintainer Term}
 Maintainer status lasts until it is resigned, or until it is revoked by Executive Board vote.
+A Maintainer may resign at any time by notifying the current Executive Board and Maintainer group.
 If a Maintainer no longer satisfies \ref{Maintainer Qualifications}, they lose Maintainer status.
 
 \asubsection{Maintainer Selection}

--- a/constitution.tex
+++ b/constitution.tex
@@ -311,7 +311,6 @@ If at any point the member's leave is determined by the Executive Board to be de
 \article{Executive Board}
 The Executive Board is the main governing body of the House.
 Its purpose is to provide leadership and direction for the House, to oversee the day-to-day operations of the House, and to initiate and organize programs and projects for the House.
-It is composed of the seven permanent directors and the Chairperson.
 \\*\\*
 There is one permanent directorship for each major aspect of the government of the House and each one is chaired by an Executive Board member.
 Ad Hoc directorships are created on an as-needed basis.

--- a/constitution.tex
+++ b/constitution.tex
@@ -117,7 +117,7 @@ A vote equaling or exceeding ninety percent of the number of votes cast is requi
 \asection{Maintainers}
 
 \asubsection{Maintainer Qualifications}
-Maintainers must be Active or Alumni in good standing.
+Maintainers must be Active or Alumni Members.
 
 \asubsection{Maintainer Expectations}
 Maintainers are expected to:

--- a/constitution.tex
+++ b/constitution.tex
@@ -181,7 +181,7 @@ Introductory membership shall last until the end of the introductory process, at
 \asubsection{Active Membership Qualifications}
 Active Membership is open to all students currently enrolled at the Rochester Institute of Technology who have passed the Introductory Evaluation and their most recent Membership Evaluation.
 \asubsection{Active Membership Selection}
-Alumni Members in good standing may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director.
+Alumni Members in good standing may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director. They will retain their previous On-Floor Status if applicable.
 \\*\\*
 Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evaluations Director of their intent to participate, who will bring them up for a Simple Majority vote at the next House meeting.
 If the vote passes the Alumni is reinstated as an Active Member effective immediately.

--- a/constitution.tex
+++ b/constitution.tex
@@ -488,7 +488,7 @@ Directorship Name & Percentage of Dues \\
 \hline
 Operational Communications & 20\% \\
 \hline
-Evaluations \& Selections & 5\% \\
+Evaluations & 5\% \\
 \hline
 House History & 10\% \\
 \hline
@@ -505,9 +505,11 @@ Accumulated & 5\% \\
 \end{tabular}
 \end{center}
 
-The suggested total operational budget is \$8064.
-This figure is based on yearly estimated on-floor member dues (\$160 x 72 members = \$11520) minus the 10\% reserved for Accumulated (Accum).
-Money allocated for Accum and off-floor member dues is deposited into the CSH Account and saved.
+% The suggested total operating budget is $8360.
+% This figure comes from having approximately 55 on-floor members with $80 per semester dues (totaling $8800) minus 5% set aside for Accumulated.
+
+Dues collected from on-floor members are to be distributed into directorship budgets as shown in the above table.
+Money allocated for Accumulated or collected from off-floor members is deposited into the CSH Account and saved.
 
 \asubsubsection{Expenditure Approval}
 All House expenditures must be approved by both the Financial Director and the appropriate Director (from whose budget the funds will be drawn).

--- a/constitution.tex
+++ b/constitution.tex
@@ -393,7 +393,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To preside over Research and Development Meetings in which House members are encouraged to bring ideas for projects
 	\item To exercise general supervision over Research and Development operations
 	\item To oversee the planning, organization and construction of technical projects for the House's benefit
-	\item To collaborate with the Operational Communications Director in an attempt to fulfill the House's need for technical equipment
+	\item To strive to fulfill the House's need for technical equipment
 	\item To provide seminars and tutorials to educate House members in technical areas
 	\item To vote on issues presented to the Executive Board
 \end{enumerate}

--- a/constitution.tex
+++ b/constitution.tex
@@ -354,7 +354,7 @@ However, the Chairperson and at least two-thirds of the Voting Members of the Ex
 	\item To act as a Judicial Board as defined in \ref{Judicial}
 	\item To review major projects, as defined in \ref{Expectations of House Members}
 	\item To make the final vote regarding conditionals and appeals as defined in \ref{Membership Evaluation}
-	\item To respect the privacy of House members confiding in the Executive Board, barring situations related to endangerment of oneself or others, sexual assault, or in the case of a Judicial Board
+	\item To respect the privacy of House Members confiding in the Executive Board, barring situations related to sexual assault or endangerment of oneself or others
 	\item To publish a document at the end of each semester to all Members stating House’s accomplishments of that semester
 	\item To review and update the Constitution at the end of each Standard Operating Session, as defined in \ref{Standard Operating Session}.
 		The constitution should remain up to date with current practices.

--- a/constitution.tex
+++ b/constitution.tex
@@ -575,7 +575,9 @@ Any of these requirements may be waived by the Evaluations Director or a simple 
 \end{enumerate}
 \asubsubsection{Selection Processes}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
-\asubsubsubsection{Selection Process for Students Attending RIT for at Least One Semester}
+
+% Current RIT students is defined as students who have attended RIT for at least 1 full semester
+\asubsubsubsection{Selection Process for Current RIT Students}
 \begin{enumerate}
 	\item The applicant submits an application to the Evaluations Director for review.
 	\item The applicant participates in an informal interview with exactly three current Active, Alumni, or Honorary Members.
@@ -588,7 +590,9 @@ The member does, however, have the right to use Computer Science House's facilit
 The member is not required to pay dues during the Introductory Process.
 \\* \\*
 Additional Note: No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
-\asubsubsubsection{Selection Process for First Semester and Entering RIT Students}
+
+% Incoming RIT students is defined as students who have attended RIT for less than 1 full semester
+\asubsubsubsection{Selection Process for Incoming RIT Students}
 \begin{enumerate}
 	\item During Spring semester, the Evaluations Director selects a group of Active Members to form a Selections Committee.
 		The Selections Committee reviews applications and conducts interviews in accordance with the process prescribed by Residence Life.

--- a/constitution.tex
+++ b/constitution.tex
@@ -133,7 +133,7 @@ If a Maintainer no longer satisfies \ref{Maintainer Qualifications}, they lose M
 
 \asubsection{Maintainer Selection}
 Any member may nominate a qualified member for Maintainer status to the Executive Board for consideration.
-The Executive Board may choose to approve or reject the nomination by Simple Majority vote.
+The Executive Board may choose to approve or reject the nomination by Simple Majority vote with a quorum of seventy-five percent of the Total Number of Possible Votes.
 
 % ARTICLE III - GENERAL OPERATIONS OF THE HOUSE
 \article{General Operations of the House}

--- a/constitution.tex
+++ b/constitution.tex
@@ -557,8 +557,8 @@ Before the end of the Process, an Introductory Member is expected to:
 \end{itemize}
 
 \asubsubsubsection{Introductory Evaluation}
-The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of full Resident or Non-Resident Membership.
-Occurs at the conclusion of the final week of the Process.
+The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of Active Membership.
+It occurs at the conclusion of the final week of the Process.
 
 \asubsubsubsubsection{Voting}
 On a member by member basis, this evaluation process determines if each Introductory member has successfully completed the Introductory Process requirements \ref{Expectations of an Introductory Member}.
@@ -607,8 +607,9 @@ Additional Note: No hazing shall occur at any time during the Selection Process 
 \begin{enumerate}
 	\item During Spring semester, the Evaluations Director selects a group of Active Members to form a Selections Committee.
 		The Selections Committee reviews applications and conducts interviews in accordance with the process prescribed by Residence Life.
-	\item A subset of applications will be selected to move onto the House Fall Semester, are granted full membership privileges (including On-Floor status), and must participate in the Introductory Process as defined in \ref{The Introductory Process}.
-		An additional subset will be given Off-Floor status, but otherwise receive the same privileges and responsibilities.
+        \item A subset of applicants will be offered Introductory Membership and must participate in the Introductory Process defined in \ref{The Introductory Process}. 
+            A subset of Introductory Members will be offered On-Floor status and will be able to select a room on floor. 
+            The other Introductory Members will have Off-Floor status, but will otherwise have the same privileges and responsibilities.
 \end{enumerate}
 Note: Most membership privileges do not initiate until successful completion of the introductory process.
 This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.

--- a/constitution.tex
+++ b/constitution.tex
@@ -540,7 +540,7 @@ If an Introductory Process is extended, the Introductory Evaluation shall occur 
 If deemed necessary by the Evaluations Director, or by an Executive Board simple majority vote, the second intro process must begin within nine (9) days of the first process ending.
 If a second Introductory Process is approved, the Evaluations Director may initiate a new Introductory Packet within the first or second week of the Introductory Process.
 \asubsubsubsection{The Introductory Packet}
-Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active Members who have passed a Membership Evaluation, all Active Resident Members, all Introductory Resident Members, and ten (10) of any combination of the following:
+Each Introductory Process participant, after the first week, is given two (2) weeks to obtain signatures from all Active Members who have passed a Membership Evaluation, all On-Floor Introductory Members, and ten (10) of any combination of the following:
 \begin{itemize}
 	\item Alumni members
 	\item Honorary members

--- a/constitution.tex
+++ b/constitution.tex
@@ -318,26 +318,9 @@ Ad Hoc directorships are created on an as-needed basis.
 They are generally very task oriented and are chaired by a House member.
 A directorship has some jurisdiction in its area of interest and often is responsible for the day-to-day decisions regarding its area of interest.
 Any large expenditures or large effect decisions must be brought before the entire House
-\asection{Members of the Executive Board}
-\asubsection{Voting Members}
-\begin{itemize}
-	\item Evaluations Director
-	\item Social Director(s)
-	\item Financial Director
-	\item Research and Development Director(s)
-	\item House Improvements Director
-	\item Operational Communications Director
-	\item House History Director
-	\item Public Relations Director
-\end{itemize}
-\asubsection{Non-Voting Members}
-\begin{itemize}
-	\item Chairperson
-	\item House Secretary
-	\item Ad Hoc Director(s)
-\end{itemize}
 
 \asection{Responsibilities}
+
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \asubsection{Responsibilities of the Executive Board}
 \begin{enumerate}
@@ -373,14 +356,16 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To collaborate with the Residence Life Advisor to determine room change selection and any changes of membership residency
 	\item To act as a part of a Judicial Board as defined in \ref{Judicial}
 	\item To prepare the House for Open Houses, tours, and special events
+	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
-\asubsection{Responsibilities of the Social Director}
+\asubsection{Responsibilities of the Social Director(s)}
 \begin{enumerate}
 	\item To preside over Social Meetings in which House members are encouraged to bring ideas for social events
 	\item To exercise general supervision over Social operations
 	\item To oversee the organization, initiation, and execution of House activities and events
 	\item To ensure that there is a variety of activities for House members to participate in throughout the academic year
+	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
 \asubsection{Responsibilities of the Public Relations Director}
@@ -390,6 +375,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To oversee the organization, initiation, and execution of House philanthropic events
 	\item To preserve and improve the public image of House
 	\item To collaborate with other Executive Board members to organize, initiate, execute, and advertise any events that are intended to be attended by persons whom have never been Active Members
+	\item To vote on issues presented to the Executive Board
 
 \end{enumerate}
 
@@ -403,15 +389,17 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To publish a semesterly House financial statement
 	\item To supervise the collection of semesterly House dues
 	\item To oversee the planning and execution of fundraising events
+	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
-\asubsection{Responsibilities of the Research and Development Director}
+\asubsection{Responsibilities of the Research and Development Director(s)}
 \begin{enumerate}
 	\item To preside over Research and Development Meetings in which House members are encouraged to bring ideas for projects
 	\item To exercise general supervision over Research and Development operations
 	\item To oversee the planning, organization and construction of technical projects for the House's benefit
 	\item To collaborate with the Operational Communications Director in an attempt to fulfill the House's need for technical equipment
 	\item To provide seminars and tutorials to educate House members in technical areas
+	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
 \asubsection{Responsibilities of the House Improvements Director}
@@ -420,12 +408,14 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To exercise general supervision over the House Improvements operations
 	\item To oversee the organization and construction of physical improvements to the House
 	\item To oversee the general maintenance of the appearance of the House
+	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
 \asubsection{Responsibilities of the Operational Communications Director}
 \begin{enumerate}
 	\item To represent the Root Type Persons at Executive Board Meetings and at House Meetings
 	\item To report the status of the House computer systems and network to the Executive Board and House members
+	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
 \asubsection{Responsibilities of the House History Director}
@@ -436,6 +426,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To collaborate with the Social Director(s) to ensure that all the Active, Alumni, and Advisory Members are informed of upcoming events
 	\item To oversee the production and distribution of a semi-annual newsletter
 	\item To oversee the creation of a yearbook outlining House events for the year
+	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
 \asubsection{Responsibilities of the House Secretary}

--- a/constitution.tex
+++ b/constitution.tex
@@ -581,7 +581,6 @@ Any of these requirements may be waived by the Evaluations Director or a simple 
 \begin{enumerate}
 	\item Introductory Members may be offered Active Membership (\ref{Active Membership}) provided they meet the requirements described in \ref{Expectations of an Introductory Member}, at the discretion of House.
 	\item If an Introductory Member fails to meet the requirements, their membership will be revoked.
-		In addition, the participant is asked to find alternative housing as soon as possible in accordance with all applicable Residence Life policies regarding room changes.
 	\item An Introductory member may be given a conditional to complete as a means of making up for missing requirements.
 		A conditional may be proposed by any member present at the Introductory Evaluation and, if it is approved by the Evaluations Director, is then voted on by House.
 		Each conditional consists of a set of additional requirements and a deadline for completing them.
@@ -995,7 +994,6 @@ An option in the vote passes if the number of votes cast for the option equals o
 \asubsection{Three-Quarters}
 In a Three-Quarters Vote, a Quorum is reached if the Total Number of Votes Cast is equal to or exceeds three-quarters the Total Number of Possible Votes.
 An option in the vote passes if the number of votes cast for the option equals or exceeds three-quarters of the Total Number of Votes Cast.
-
 \asubsection{Alternative}
 The winning option is selected outright if it gains more than half the votes cast as a first preference.
 If not, the option with the fewest number of first preference votes is eliminated and their votes move to the second preference marked on the ballot papers.

--- a/constitution.tex
+++ b/constitution.tex
@@ -118,11 +118,10 @@ Maintainers must be Active or Alumni Members.
 \asubsection{Maintainer Expectations}
 Maintainers are expected to:
 \begin{itemize}
-	\item Review changes to the Constitution for grammar, spelling, and internal consistency
-	\item Keep a public record of changes to the Constitution
-	\item Participate in discussion of proposals
-	\item Facilitate the creation of new changes to the Constitution by other members
 	\item Be knowledgeable about the Constitution
+	\item Review changes to the Constitution for grammar, spelling, and internal consistency
+	\item Participate in discussion of proposals and amendments
+	\item Keep a public record of changes to the Constitution
 \end{itemize}
 Failure to meet any of these expectations is grounds for revocation of Maintainer status by the Executive Board.
 


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Alumni now always have a housing status, which will be kept when returning to active membership. When an active member enters alumni membership with good standing, they keep their current housing status. If they enter bad standing, they are automatically assigned Off-Floor status.