### PR TITLE
Resolve #50 Packet Document

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -538,7 +538,7 @@ If an Introductory Process is extended, the Introductory Evaluation shall occur 
 If deemed necessary by the Evaluations Director, or by an Executive Board simple majority vote, the second intro process must begin within nine (9) days of the first process ending.
 If a second Introductory Process is approved, the Evaluations Director may initiate a new Introductory Packet within the first or second week of the Introductory Process.
 \asubsubsubsection{The Introductory Packet}
-Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active Members who have passed a Membership Evaluation, all Active Resident Members, all Introductory Resident Members, and ten (10) of any combination of the following:
+Each Introductory Process participant, after the first week, is given two (2) weeks to obtain signatures from all Active Members who have passed a Membership Evaluation, all On-Floor Introductory Members, and ten (10) of any combination of the following:
 \begin{itemize}
 	\item Alumni members
 	\item Honorary members


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Remove all references to a physical packet document

resolves #50 