### PR TITLE
Resolve #67 4.B.4 Remove Last Paragraph

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -205,8 +205,6 @@ Active Members receive the right to:
 	\item Receive priority for available housing on the House when returning from cooperative education
 	\item Guaranteed housing in compliance with the Residence Life policies regarding Special Interest Houses and the Housing Selection Process (if they have On-Floor status)
 \end{itemize}
-Active Members currently on co-op forfeit their right to vote on house issues, and likewise do not count towards quorum.
-Exceptions may be made at the discretion of the Evaluations Director.
 \asubsection{Active Membership Evaluations}
 Active Members are evaluated annually through the Evaluation Process as described in \ref{Evaluations Processes}.
 \asubsection{Active Membership Leave of Absence}
@@ -488,7 +486,7 @@ Directorship Name & Percentage of Dues \\
 \hline
 Operational Communications & 20\% \\
 \hline
-Evaluations & 5\% \\
+Evaluations \& Selections & 5\% \\
 \hline
 House History & 10\% \\
 \hline
@@ -505,11 +503,9 @@ Accumulated & 5\% \\
 \end{tabular}
 \end{center}
 
-% The suggested total operating budget is $8360.
-% This figure comes from having approximately 55 on-floor members with $80 per semester dues (totaling $8800) minus 5% set aside for Accumulated.
-
-Dues collected from on-floor members are to be distributed into directorship budgets as shown in the above table.
-Money allocated for Accumulated or collected from off-floor members is deposited into the CSH Account and saved.
+The suggested total operational budget is \$8064.
+This figure is based on yearly estimated on-floor member dues (\$160 x 72 members = \$11520) minus the 10\% reserved for Accumulated (Accum).
+Money allocated for Accum and off-floor member dues is deposited into the CSH Account and saved.
 
 \asubsubsection{Expenditure Approval}
 All House expenditures must be approved by both the Financial Director and the appropriate Director (from whose budget the funds will be drawn).
@@ -583,6 +579,7 @@ Any of these requirements may be waived by the Evaluations Director or a simple 
 \begin{enumerate}
 	\item Introductory Members may be offered Active Membership (\ref{Active Membership}) provided they meet the requirements described in \ref{Expectations of an Introductory Member}, at the discretion of House.
 	\item If an Introductory Member fails to meet the requirements, their membership will be revoked.
+		In addition, the participant is asked to find alternative housing as soon as possible in accordance with all applicable Residence Life policies regarding room changes.
 	\item An Introductory member may be given a conditional to complete as a means of making up for missing requirements.
 		A conditional may be proposed by any member present at the Introductory Evaluation and, if it is approved by the Evaluations Director, is then voted on by House.
 		Each conditional consists of a set of additional requirements and a deadline for completing them.
@@ -996,6 +993,7 @@ An option in the vote passes if the number of votes cast for the option equals o
 \asubsection{Three-Quarters}
 In a Three-Quarters Vote, a Quorum is reached if the Total Number of Votes Cast is equal to or exceeds three-quarters the Total Number of Possible Votes.
 An option in the vote passes if the number of votes cast for the option equals or exceeds three-quarters of the Total Number of Votes Cast.
+
 \asubsection{Alternative}
 The winning option is selected outright if it gains more than half the votes cast as a first preference.
 If not, the option with the fewest number of first preference votes is eliminated and their votes move to the second preference marked on the ballot papers.

--- a/constitution.tex
+++ b/constitution.tex
@@ -486,7 +486,7 @@ Directorship Name & Percentage of Dues \\
 \hline
 Operational Communications & 20\% \\
 \hline
-Evaluations \& Selections & 5\% \\
+Evaluations & 5\% \\
 \hline
 House History & 10\% \\
 \hline
@@ -503,9 +503,11 @@ Accumulated & 5\% \\
 \end{tabular}
 \end{center}
 
-The suggested total operational budget is \$8064.
-This figure is based on yearly estimated on-floor member dues (\$160 x 72 members = \$11520) minus the 10\% reserved for Accumulated (Accum).
-Money allocated for Accum and off-floor member dues is deposited into the CSH Account and saved.
+% The suggested total operating budget is $8360.
+% This figure comes from having approximately 55 on-floor members with $80 per semester dues (totaling $8800) minus 5% set aside for Accumulated.
+
+Dues collected from on-floor members are to be distributed into directorship budgets as shown in the above table.
+Money allocated for Accumulated or collected from off-floor members is deposited into the CSH Account and saved.
 
 \asubsubsection{Expenditure Approval}
 All House expenditures must be approved by both the Financial Director and the appropriate Director (from whose budget the funds will be drawn).
@@ -579,7 +581,6 @@ Any of these requirements may be waived by the Evaluations Director or a simple 
 \begin{enumerate}
 	\item Introductory Members may be offered Active Membership (\ref{Active Membership}) provided they meet the requirements described in \ref{Expectations of an Introductory Member}, at the discretion of House.
 	\item If an Introductory Member fails to meet the requirements, their membership will be revoked.
-		In addition, the participant is asked to find alternative housing as soon as possible in accordance with all applicable Residence Life policies regarding room changes.
 	\item An Introductory member may be given a conditional to complete as a means of making up for missing requirements.
 		A conditional may be proposed by any member present at the Introductory Evaluation and, if it is approved by the Evaluations Director, is then voted on by House.
 		Each conditional consists of a set of additional requirements and a deadline for completing them.
@@ -993,7 +994,6 @@ An option in the vote passes if the number of votes cast for the option equals o
 \asubsection{Three-Quarters}
 In a Three-Quarters Vote, a Quorum is reached if the Total Number of Votes Cast is equal to or exceeds three-quarters the Total Number of Possible Votes.
 An option in the vote passes if the number of votes cast for the option equals or exceeds three-quarters of the Total Number of Votes Cast.
-
 \asubsection{Alternative}
 The winning option is selected outright if it gains more than half the votes cast as a first preference.
 If not, the option with the fewest number of first preference votes is eliminated and their votes move to the second preference marked on the ballot papers.


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Resolves #67 by removing last paragraph about voting exemptions for Active members on co-op in 4.B.4.
