### PR TITLE
Resolves #83 Allow Maintainers to be Alumni in Bad Standing

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -117,7 +117,7 @@ A vote equaling or exceeding ninety percent of the number of votes cast is requi
 \asection{Maintainers}
 
 \asubsection{Maintainer Qualifications}
-Maintainers must be Active or Alumni in good standing.
+Maintainers must be Active or Alumni Members.
 
 \asubsection{Maintainer Expectations}
 Maintainers are expected to:


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Resolves #83 by allowing Maintainers to be Alumni in bad standing.