### PR TITLE
Resolves #86 Add Quorum Requirement for Maintainer Nominations

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -137,7 +137,7 @@ If a Maintainer no longer satisfies \ref{Maintainer Qualifications}, they lose M
 
 \asubsection{Maintainer Selection}
 Any member may nominate a qualified member for Maintainer status to the Executive Board for consideration.
-The Executive Board may choose to approve or reject the nomination by Simple Majority vote.
+The Executive Board may choose to approve or reject the nomination by Simple Majority vote with a quorum of seventy-five percent of the Total Number of Possible Votes.
 
 % ARTICLE III - GENERAL OPERATIONS OF THE HOUSE
 \article{General Operations of the House}


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Resolves #86 by adding a proposed quorum requirement to vote on Maintainer nominations.