### PR TITLE
87 remove week number standard operating session

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -115,7 +115,6 @@ Many of the commonly used abbreviations will be listed here, and the abbreviatio
 
 \asection{Constitution}
 The House Constitution is written and maintained by the House and defines the major aspects, goals, and governing structure of the house.
-It is reviewed annually by ResLife.
 
 \asubsection{Non-Semantic Changes}
 There are two methods for non-semantic change to the Constitution.

--- a/constitution.tex
+++ b/constitution.tex
@@ -88,20 +88,25 @@ The objectives of Computer Science House are:
 \end{enumerate}
 
 \article{Abbreviations and Definitions}
+Many of the commonly used abbreviations will be listed here, and the abbreviations will be used throughout the rest of the document.
 
-\begin{itemize}
-	\item Evaluations Director - Evals Director
-	\item Research and Development Director(s) - R\&D Director(s)
-	\item House Improvements Director - Imps Director
-	\item Operational Communications Director - OpComm Director
-	\item House History Director - History Director
-	\item Public Relations Director - PR Director
-	\item Root Type Persons - RTPs
-	\item Introductory Member - Intro Member
-	\item Introductory Process - Intro Process
-	\item Introductory Evaluations - Intro Evals
-	\item Executive Board - E-Board
-\end{itemize}
+\begin{enumerate}
+	\item Chair - Chariperson
+	\item Evals - Evaluations
+	\item R\&D - Research and Development
+	\item IMPs - House Improvements
+	\item Operational Communications - OpComm
+	\item History - House History
+	\item PR - Public Relations
+	\item Socials - Social
+	\item Financials - Financial
+	\item RTP - Root Type Person
+	\item Intro - Introductory
+	\item E-Board - Executive Board
+	\item ResLife - Residence Life
+	\item Maintainer - Constitutional Maintainer
+\end{enumerate}
+
 
 % ARTICLE II - CONSTITUTIONAL STRUCTURE
 \article{Constitutional Structure}
@@ -184,7 +189,7 @@ When describing the different memberships available, the following terms are use
 \asubsection{Introductory Membership Qualifications}
 Introductory Membership is open to all students at the Rochester Institute of Technology.
 \asubsection{Introductory Membership Selection}
-Applicants notify the House of their interest in membership by submitting an application to the Evaluations Director.
+Applicants notify the House of their interest in membership by submitting an application to the Evals Director.
 They must then undergo the selection process as defined in \ref{Selection Processes}.
 \asubsection{Introductory Membership Expectations}
 Introductory members are expected to meet all the requirements of the Introductory Process, as described in \ref{Expectations of an Introductory Member}.
@@ -192,21 +197,21 @@ Introductory members are expected to meet all the requirements of the Introducto
 Introductory members receive the right to use Computer Science House facilities, to attend House functions, and to have housing priority over all persons who are not Computer Science House members.
 \asubsection{Introductory Membership Evaluations}
 Introductory members are evaluated on their performance during the introductory period.
-The introductory evaluation process is described in \ref{Introductory Evaluation}.
+The introductory evals process is described in \ref{Introductory Evaluation}.
 \asubsection{Introductory Membership Leave of Absence}
 After completion of the Introductory Packet, an Introductory member may request a leave of absence through the process described in \ref{Leave of Absence}.
 \asubsection{Introductory Membership Resignations}
-Introductory members may resign by submitting the request for termination of membership to the Chairperson, or Evaluations Director in writing before the completion of the introductory process.
+Introductory members may resign by submitting the request for termination of membership to the Chair, or Evals Director in writing before the completion of the introductory process.
 \asubsection{Introductory Membership Term}
 Introductory membership shall last until the end of the introductory process, at which time active membership is granted or membership is revoked.
 
 \asection{Active Membership}
 \asubsection{Active Membership Qualifications}
-Active Membership is open to all students currently enrolled at the Rochester Institute of Technology who have passed the Introductory Evaluation and their most recent Membership Evaluation.
+Active Membership is open to all students currently enrolled at the Rochester Institute of Technology who have passed the Introductory Evals and their most recent Membership Evals.
 \asubsection{Active Membership Selection}
-Qualifying members may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director.
+Qualifying members may self-select into Active Membership by paying dues to the Financial Director and notifying the Evals Director.
 \\*\\*
-Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evaluations Director of their intent to participate, who will bring them up for a Simple Majority vote at the next House meeting.
+Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evals Director of their intent to participate, who will bring them up for a Simple Majority vote at the next House meeting.
 If the vote passes the Alumni is reinstated as an Active Member with Off-Floor status effective immediately.
 \asubsection{Active Membership Expectations}
 Active members are expected to be active participants in the House as defined in \ref{Expectations of House Members}.
@@ -222,9 +227,9 @@ Active Members receive the right to:
 	\item Guaranteed housing in compliance with the Residence Life policies regarding Special Interest Houses and the Housing Selection Process (if they have On-Floor status)
 \end{itemize}
 Active Members currently on co-op forfeit their right to vote on house issues, and likewise do not count towards quorum.
-Exceptions may be made at the discretion of the Evaluations Director.
+Exceptions may be made at the discretion of the Evals Director.
 \asubsection{Active Membership Evaluations}
-Active Members are evaluated annually through the Evaluation Process as described in \ref{Evaluations Processes}.
+Active Members are evaluated annually through the Evals Process as described in \ref{Evaluations Processes}.
 \asubsection{Active Membership Leave of Absence}
 An Active member may at any time request a leave of absence using the process described in \ref{Leave of Absence}.
 For the duration of an absence, a member:
@@ -234,7 +239,7 @@ For the duration of an absence, a member:
 	\item Will not be required to attend House Meeting
 \end{itemize}
 \asubsection{Active Membership Resignations}
-An Active member may resign by submitting, in writing, the reason for resignation to the Chairperson, or Evaluations Director.
+An Active member may resign by submitting, in writing, the reason for resignation to the Chair, or Evals Director.
 Instead of forfeiting membership, Active members who resign may elect to become Alumni defined in \ref{Alumni Membership Selection}.
 The resignation will take effect immediately and an announcement will be made at the following House Meeting.
 \asubsection{Active Membership Term}
@@ -242,11 +247,11 @@ Active Membership shall last until the member: resigns or changes membership sta
 
 \asection{Alumni Membership}
 \asubsection{Alumni Membership Qualifications}
-Alumni Membership is open to all former Active members of Computer Science House who passed at least one Membership Evaluation and departed for reasons other than revocation of House Membership.
+Alumni Membership is open to all former Active members of Computer Science House who passed at least one Membership Evals and departed for reasons other than revocation of House Membership.
 \asubsection{Alumni Membership Selection}
-Active members who depart house (i.e. resign) after passing the current operating session's Membership Evaluations are considered to be Alumni in good standing.
+Active members who depart house (i.e. resign) after passing the current operating session's Membership Evals are considered to be Alumni in good standing.
 \\*\\*
-Active members who depart house without passing the current operating session's Membership Evaluations are considered to be Alumni in bad standing.
+Active members who depart house without passing the current operating session's Membership Evals are considered to be Alumni in bad standing.
 This may be appealed to the Executive Board in order to pursue a different outcome.
 \asubsection{Alumni Membership Expectations}
 There are no expectations associated with the Alumni Membership status.
@@ -267,8 +272,8 @@ Alumni Membership shall last indefinitely or until the member chooses to pursue 
 \asubsection{Honorary Membership Qualifications}
 Honorary Membership is open to a person whom the House feels has contributed great personal effort to the House and is deserving of House recognition.
 \asubsection{Honorary Membership Selection}
-Any House member may nominate a candidate for Honorary Membership by submitting the name in writing to the Evaluations Director.
-The Evaluation Director then begins the Honorary Membership Selection Process as defined in \ref{Selection Process for Honorary Members}
+Any House member may nominate a candidate for Honorary Membership by submitting the name in writing to the Evals Director.
+The Evals Director then begins the Honorary Membership Selection Process as defined in \ref{Selection Process for Honorary Members}
 \asubsection{Honorary Membership Expectations}
 Honorary Members are encouraged to remain in contact with the House.
 \asubsection{Honorary Membership Privileges}
@@ -276,7 +281,7 @@ Honorary Members may advise in all issues brought before the House, use Computer
 \asubsection{Honorary Membership Evaluations}
 Honorary Members are not subject to formal evaluations.
 \asubsection{Honorary Membership Resignations}
-An Honorary Member may resign by submitting in writing the reason for resignation to the Chairperson.
+An Honorary Member may resign by submitting in writing the reason for resignation to the Chair.
 The resignation will be read at the following House Meeting and become effective at that time.
 \asubsection{Honorary Membership Term}
 Honorary Membership shall last until the member resigns.
@@ -295,7 +300,7 @@ Advisory Members may advise in all issues brought before the House, use Computer
 \asubsection{Advisory Membership Evaluations}
 Advisors are not subject to formal evaluations.
 \asubsection{Advisory Membership Resignations}
-An Advisor may resign by submitting in writing the reason for resignation to the Chairperson.
+An Advisor may resign by submitting in writing the reason for resignation to the Chair.
 The resignation will be read at the following House Meeting and become effective at that time.
 \asubsection{Advisory Membership Term}
 Advisory Membership shall last until the member resigns.
@@ -304,7 +309,7 @@ Advisory Membership shall last until the member resigns.
 A leave of absence offers the option for members to take extended time away from their responsibilities to House for any number of personal issues including, but not limited to, physical illness, mental illness, or care giving for a sick family member.
 Computer Science House recognizes the need for its members to take care of their personal well-being and will support them through the process of requesting a leave of absence.
 House will also help to reacclimate any returning member back to the culture of House upon their return.
-Upon approval of a leave of absence request, the Evaluations Director is notified and the member's leave is applied immediately.
+Upon approval of a leave of absence request, the Evals Director is notified and the member's leave is applied immediately.
 A member is also allowed to be physically present and also be on a leave of absence.
 \asubsection{Leave of Absence Request}
 A leave of absence request must include the following information about the member: name, email, phone number, start date, expected return date, and a reason for the leave.
@@ -329,7 +334,7 @@ If at any point the member's leave is determined by the Executive Board to be de
 \article{Executive Board}
 The Executive Board is the main governing body of the House.
 Its purpose is to provide leadership and direction for the House, to oversee the day-to-day operations of the House, and to initiate and organize programs and projects for the House.
-It is composed of the seven permanent directors and the Chairperson.
+It is composed of the seven permanent directors and the Chair.
 \\*\\*
 There is one permanent directorship for each major aspect of the government of the House and each one is chaired by an Executive Board member.
 Ad Hoc directorships are created on an as-needed basis.
@@ -339,10 +344,10 @@ Any large expenditures or large effect decisions must be brought before the enti
 \asection{Members of the Executive Board}
 \asubsection{Voting Members}
 \begin{itemize}
-	\item Evaluations Director
+	\item Evals Director
 	\item Social Director(s)
 	\item Financial Director
-	\item Research and Development Director(s)
+	\item R\&D Director(s)
 	\item House Improvements Director
 	\item Operational Communications Director
 	\item House History Director
@@ -350,14 +355,14 @@ Any large expenditures or large effect decisions must be brought before the enti
 \end{itemize}
 \asubsection{Non-Voting Members}
 \begin{itemize}
-	\item Chairperson
+	\item Chair
 	\item House Secretary
 	\item Ad Hoc Director(s)
 \end{itemize}
 \asection{Closed Executive Board}
-Closed Executive Board Meetings are open only to the Chairperson, Voting Members of the Executive Board, and those with the express permission of the Executive Board.
+Closed Executive Board Meetings are open only to the Chair, Voting Members of the Executive Board, and those with the express permission of the Executive Board.
 A closed Executive Board meeting may be called at any time by any member of the Executive Board.
-However, the Chairperson and at least two-thirds of the Voting Members of the Executive Board must be present for the meeting to be called.
+However, the Chair and at least two-thirds of the Voting Members of the Executive Board must be present for the meeting to be called.
 
 \asection{Responsibilities}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
@@ -376,7 +381,7 @@ However, the Chairperson and at least two-thirds of the Voting Members of the Ex
 		The constitution should remain up to date with current practices.
 \end{enumerate}
 
-\asubsection{Responsibilities of the Chairperson}
+\asubsection{Responsibilities of the Chair}
 \begin{enumerate}
 	\item To preside over Executive Board and House Meetings
 	\item To exercise general supervision over the operations of the Executive Board
@@ -388,10 +393,10 @@ However, the Chairperson and at least two-thirds of the Voting Members of the Ex
 
 \asubsection{Responsibilities of the Evaluations Director}
 \begin{enumerate}
-	\item To preside over Evaluations Meetings
-	\item To exercise general supervision over Evaluations operations
+	\item To preside over Evals Meetings
+	\item To exercise general supervision over Evals operations
 	\item To oversee the screening, interviewing, and acceptance or rejection of prospective House members
-	\item To oversee the Semi-Annual Evaluations of current House members
+	\item To oversee the Semi-Annual Evals of current House members
 	\item To collaborate with the Residence Life Advisor to determine room change selection and any changes of membership residency
 	\item To act as a part of a Judicial Board as defined in \ref{Judicial}
 	\item To prepare the House for Open Houses, tours, and special events
@@ -493,7 +498,7 @@ If the Executive Board disagrees with the Financial Director, the Executive Boar
 If the Executive Board agrees with the Financial director, the member’s payment is considered delinquent and the member’s privileges are revoked until payment can be made.
 In the case the Financial Director or Executive Board decides the situation is appropriate, the member's dues may be partially or fully excused, or the member may be given additional time to pay their dues. 
 Additional time and reduction of dues may both be given to a member in an appropriate situation.
-All dues must be collected in full before the annual membership evaluation (\ref{Membership Evaluation}).
+All dues must be collected in full before the annual membership evals (\ref{Membership Evaluation}).
 After this date, dues collection is suspended until the start of the next academic year.
 \asubsubsection{Breakdown of Dues for Directorship Budgets}
 \begin{center}
@@ -504,7 +509,7 @@ Directorship Name & Percentage of Dues \\
 \hline
 Operational Communications & 20\% \\
 \hline
-Evaluations \& Selections & 5\% \\
+Evals & 5\% \\
 \hline
 House History & 10\% \\
 \hline
@@ -548,19 +553,19 @@ Funds allocated for a project not spent by the end of the Standard Operating Ses
 The Introductory Process is designed to provide an easy means for Introductory Members to meet existing House members, learn House history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
 \asubsubsubsection{The Evaluation Period}
 The Process will occur either once or twice per semester, and will last for six (6) weeks.
-The Process shall be initiated by the Evaluations Director during either the first and second week of each semester.
+The Process shall be initiated by the Evals Director during either the first and second week of each semester.
 The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
 If an Introductory Process is extended, the Introductory Evaluation shall occur at the termination of the extended Process, which may be outside of the period defined in \ref{Introductory Evaluation}.
-If deemed necessary by the Evaluations Director, or by an Executive Board simple majority vote, the second intro process must begin within nine (9) days of the first process ending.
-If a second Introductory Process is approved, the Evaluations Director may initiate a new Introductory Packet within the first or second week of the Introductory Process.
+If deemed necessary by the Evals Director, or by an Executive Board simple majority vote, the second intro process must begin within nine (9) days of the first process ending.
+If a second Introductory Process is approved, the Evals Director may initiate a new Introductory Packet within the first or second week of the Introductory Process.
 \asubsubsubsection{The Introductory Packet}
-Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active Members who have passed a Membership Evaluation, all Active Resident Members, all Introductory Resident Members, and ten (10) of any combination of the following:
+Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active Members who have passed a Membership Evals, all Active Resident Members, all Introductory Resident Members, and ten (10) of any combination of the following:
 \begin{itemize}
 	\item Alumni members
 	\item Honorary members
 	\item Advisory members
 \end{itemize}
-At the discretion of the Evaluations Director, any Introductory Packet may be extended to accommodate extenuating circumstances.
+At the discretion of the Evals Director, any Introductory Packet may be extended to accommodate extenuating circumstances.
 \asubsubsubsection{Expectations of an Introductory Member}
 Before the end of the Process, an Introductory Member is expected to:
 \begin{itemize}
@@ -583,8 +588,8 @@ In order for an Active Member to be counted as a Possible Vote they must meet th
 Neither absentee nor proxy votes are allowed.
 House may choose any of the Outcomes for each member.
 \asubsubsubsubsection{Expectations of Voting Members}
-The following requirements must be met by the beginning of the Introductory Evaluation for an Active Member to be allowed to vote. 
-Any of these requirements may be waived by the Evaluations Director or a simple majority vote by the Executive Board
+The following requirements must be met by the beginning of the Introductory Evals for an Active Member to be allowed to vote. 
+Any of these requirements may be waived by the Evals Director or a simple majority vote by the Executive Board
 \begin{itemize}
 \item Attend all House meetings during the process
 \item Attend at least one House directorship meeting for each week of the process (including permanent and Ad Hoc directorship meetings)
@@ -599,7 +604,7 @@ Any of these requirements may be waived by the Evaluations Director or a simple 
 	\item If an Introductory Member fails to meet the requirements, their membership will be revoked.
 		In addition, the participant is asked to find alternative housing as soon as possible in accordance with all applicable Residence Life policies regarding room changes.
 	\item An Introductory member may be given a conditional to complete as a means of making up for missing requirements.
-		A conditional may be proposed by any member present at the Introductory Evaluation and, if it is approved by the Evaluations Director, is then voted on by House.
+		A conditional may be proposed by any member present at the Introductory Evals and, if it is approved by the Evals Director, is then voted on by House.
 		Each conditional consists of a set of additional requirements and a deadline for completing them.
 		When the deadline expires, the conditional will be brought before the Executive Board who will assess its completeness.
 		A conditional member who does not meet these additional requirements forfeits membership.
@@ -608,34 +613,34 @@ Any of these requirements may be waived by the Evaluations Director or a simple 
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \asubsubsubsection{Selection Process for Students Attending RIT for at Least One Semester}
 \begin{enumerate}
-	\item The applicant submits an application to the Evaluations Director for review.
+	\item The applicant submits an application to the Evals Director for review.
 	\item The applicant participates in an informal interview with exactly three current Active, Alumni, or Honorary Members.
-	\item The application materials are then reviewed at an Evaluations meeting.
+	\item The application materials are then reviewed at an Evals meeting.
 	Then a simple majority vote, of attending members, is held on whether or not to accept the person as an Introductory Member.
 \end{enumerate}
 Note: Most membership privileges do not initiate until successful completion of the introductory process.
-This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
+This means that until the member has passed the Introductory Evals, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
 The member does, however, have the right to use Computer Science House's facilities.
 The member is not required to pay dues during the Introductory Process.
 \\* \\*
 Additional Note: No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
 \asubsubsubsection{Selection Process for First Semester and Entering RIT Students}
 \begin{enumerate}
-	\item During Spring semester, the Evaluations Director selects a group of Active Members to form a Selections Committee.
+	\item During Spring semester, the Evals Director selects a group of Active Members to form a Selections Committee.
 		The Selections Committee reviews applications and conducts interviews in accordance with the process prescribed by Residence Life.
 	\item A subset of applications will be selected to move onto the House Fall Semester, are granted full membership privileges (including On-Floor status), and must participate in the Introductory Process as defined in \ref{The Introductory Process}.
 		An additional subset will be given Off-Floor status, but otherwise receive the same privileges and responsibilities.
 \end{enumerate}
 Note: Most membership privileges do not initiate until successful completion of the introductory process.
-This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
+This means that until the member has passed the Introductory Evals, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
 The member does, however, have the right to use Computer Science House's facilities.
 The member is not required to pay dues during the Introductory Process.
 \\* \\*
 Additional Note: No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
 \asubsubsubsection{Selection Process for Honorary Members}
 \begin{enumerate}
-	\item A House Member submits to the Evaluations Director a nomination for a person they feel is deserving of Honorary Membership.
-	\item The Evaluations Director performs some preliminary research on the candidate and presents the findings.
+	\item A House Member submits to the Evals Director a nomination for a person they feel is deserving of Honorary Membership.
+	\item The Evals Director performs some preliminary research on the candidate and presents the findings.
 	\item The Executive Board decides whether or not to present the nomination to the House for a secret ballot House vote.
 		If the Executive Board decides not to present the nomination to the House, the Selection Process ends and the candidate does not become an Honorary Member.
 	\item The nomination is presented at a House Meeting for discussion and a Two-Thirds vote, as described in \ref{Two-Thirds}.
@@ -654,36 +659,36 @@ Additional Note: No hazing shall occur at any time during the Selection Process 
 \end{enumerate}
 
 \asubsubsection{Evaluations Processes}
-During the academic year, a House member is evaluated by the Membership Evaluation.
-The Membership Evaluation is responsible for determining those individuals who will have the option to continue Active Membership in the following year.
-Semi-Annual Evaluations Meetings are open only to current Active Members.
-All Executive Board members are expected to attend the Semi-Annual Evaluations Meetings to assist in the evaluations of House members.
+During the academic year, a House member is evaluated by the Membership Evals.
+The Membership Evals is responsible for determining those individuals who will have the option to continue Active Membership in the following year.
+Semi-Annual Evals Meetings are open only to current Active Members.
+All Executive Board members are expected to attend the Semi-Annual Evals Meetings to assist in the evaluations of House members.
 \\* \\*
-At the beginning of any Evaluation Process listed herein, the Evaluations Director must read the sections of the Computer Science House Constitution used during the respective Evaluation Process.
-It is incumbent upon each House member to provide the Evaluation Director with whatever information they feel is necessary to ensure an accurate evaluation.
+At the beginning of any Evals Process listed herein, the Evals Director must read the sections of the Computer Science House Constitution used during the respective Evals Process.
+It is incumbent upon each House member to provide the Evals Director with whatever information they feel is necessary to ensure an accurate evaluation.
 \asubsubsubsection{Membership Evaluation}
 The Membership Evaluation process occurs once per academic year.
-It is performed as part of the Evaluation Process that takes place during the spring semester to comply with RIT Housing deadlines.
+It is performed as part of the Evals Process that takes place during the spring semester to comply with RIT Housing deadlines.
 \asubsubsubsubsection{Voting}
-Any Active Member who has completed all of the requirements as defined in \ref{Expectations of House Members} at the beginning of the Membership Evaluation passes their Membership Evaluation without being voted on or evaluated by the quorum.
-All Active Members who have not recieved an exemption from the Executive Board prior to the Membership Evaluation will be evaluated on a Member by Member basis by a quorum of Active Members.
-The Membership Evaluation shall hold members to the objective requirements defined in \ref{Expectations of House Members} and determine which members may continue as an Active Member in the following Standard Operating Session.
+Any Active Member who has completed all of the requirements as defined in \ref{Expectations of House Members} at the beginning of the Membership Evals passes their Membership Evals without being voted on or evaluated by the quorum.
+All Active Members who have not recieved an exemption from the Executive Board prior to the Membership Evals will be evaluated on a Member by Member basis by a quorum of Active Members.
+The Membership Evals shall hold members to the objective requirements defined in \ref{Expectations of House Members} and determine which members may continue as an Active Member in the following Standard Operating Session.
 Exceptions to the requirements may be made, as House may choose any of the Outcomes for each Member, even if the Member being evaluated has not completed all of their requirements.
-These requirements must be completed before the Membership Evaluation occurs.
+These requirements must be completed before the Membership Evals occurs.
 A Secret Immediate Simple Majority vote with a Quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.
 Neither absentee nor proxy votes are allowed.
 
 
 \asubsubsubsubsection{Outcomes}
-Members who pass Membership Evaluation have the option to participate as an Active Member in the following year and remain on the upcoming roster if applicable.
+Members who pass Membership Evals have the option to participate as an Active Member in the following year and remain on the upcoming roster if applicable.
 \\* \\*
-If a member fails and has never passed a Membership Evaluation in the past, their membership will be revoked immediately.
-If the member has previously passed a Membership Evaluation they will move to Alumni Membership status at the end of the Standard Operating Session (\ref{Alumni Membership Selection}).
+If a member fails and has never passed a Membership Evals in the past, their membership will be revoked immediately.
+If the member has previously passed a Membership Evals they will move to Alumni Membership status at the end of the Standard Operating Session (\ref{Alumni Membership Selection}).
 In either case, the member forfeits their ability to be included on the following year’s roster.
 \\* \\*
 A member may be given a conditional to complete as a means of making up for missing requirements.
 A conditional may be proposed by any member present at the Evaluation.
-If the conditional is approved by the Evaluations Director, it is then voted on by House.
+If the conditional is approved by the Evals Director, it is then voted on by House.
 Each conditional consists of a set of additional requirements a deadline for completing them.
 When the deadline expires, the conditional will be brought before the Executive Board who will assess its completeness.
 A conditional member who does not meet these additional requirements will have failed the evaluation.
@@ -707,8 +712,8 @@ This status indicates their right to priority housing on the floor.
 Any Alumni Member in good standing will maintain their previous On Floor status upon a return to Active membership.
 \asubsubsubsection{On-Floor Status}
 Members with On-Floor status are eligible to live on the floor.
-To be granted On-Floor status, members may notify the Evaluations Director that they would like to come up for a vote.
-The Evaluations Director will then bring them up for vote at the next meeting.
+To be granted On-Floor status, members may notify the Evals Director that they would like to come up for a vote.
+The Evals Director will then bring them up for vote at the next meeting.
 \asubsubsubsection{Off-Floor Status}
 Members with Off-Floor status do not have the right to live on the floor.
 They still have access to all other privileges associated with their membership, and may still accumulate Housing Priority Points.
@@ -716,7 +721,7 @@ They still have access to all other privileges associated with their membership,
 \asubsubsection{Housing Priority System}
 The Housing Priority System is a means for determining the priority a House member has in a Housing issue such as Single Room Assignment or the Assignment of Available Housing.
 The member with top priority is the member with on-floor status and the most Housing Priority Points.
-Housing Priority Points are accumulated once per Operating Session at the conclusion of the Membership Evaluation. Each Active Member who passes the Membership Evaluation is granted two (2) Housing Priority Points.
+Housing Priority Points are accumulated once per Operating Session at the conclusion of the Membership Evals. Each Active Member who passes the Membership Evals is granted two (2) Housing Priority Points.
 \\* \\*
 In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
 \asubsubsubsection{Single Room Assignments}
@@ -764,7 +769,7 @@ Before introductory, active, or alumni members may receive an account they must:
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \begin{enumerate}
 	\item Sign the Code of Conduct sheets pertaining to the responsible utilization of Computer Science House and Rochester Institute of Technology facilities.
-	\item Obtain greater than or equal to 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evaluation) in the Introductory Packet or successfully complete Introductory Evaluations.
+	\item Obtain greater than or equal to 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evals) in the Introductory Packet or successfully complete Introductory Evals.
 \end{enumerate}
 Accounts for honorary and advisory members may be created at the discretion of the Root Type Persons.
 
@@ -783,12 +788,12 @@ The following process is used for making changes to the Code of Conduct document
 
 
 \asection{Qualifications}
-\asubsection{Qualifications to be the Chairperson, Evaluations Director}
+\asubsection{Qualifications to be the Chair, Evals Director}
 \begin{enumerate}
 	\item Candidates must be Active Members during the term of office
 	\item Candidates must reside on floor during the term of office
 	\item Candidates must have at least one full semester of House membership as an Active Member
-	\item Elected or selected candidates may not hold a simultaneous voting Executive Board position, and must therefore resign their current position, or the position of Chairperson, should they be elected
+	\item Elected or selected candidates may not hold a simultaneous voting Executive Board position, and must therefore resign their current position, or the position of Chair, should they be elected
 \end{enumerate}
 \asubsection{Qualifications to be the Social Director(s), Financial Director, Research and Development Director(s), House Improvements Director, House History Director, Public Relations Director}
 \begin{enumerate}
@@ -839,7 +844,7 @@ The following special cases cover the operation of a dual directorship:
 	\item A member of a dual directorship may not hold any other Executive Board position.
 	\item When attendance requirements call for the dual directorship position to be present, both dual directorship members are to fulfill the requirements.
 \end{itemize}
-\asubsection{Selection of the Chairperson, Evaluations Director, Social Director(s), Financial Director, House Improvements Director, House History Director, Research and Development Director(s), Public Relations Director}
+\asubsection{Selection of the Chair, Evals Director, Social Director(s), Financial Director, House Improvements Director, House History Director, Research and Development Director(s), Public Relations Director}
 \begin{enumerate}
 	\item The opening of the Executive Board position(s) is announced at a House meeting and nominations for the position are taken for a minimum of a seventy-two hour period.
 		Any House member may nominate any member or pair of members where appropriate for a Directorship.
@@ -848,12 +853,12 @@ The following special cases cover the operation of a dual directorship:
 		A list of all nominees who have accepted their nominations will be posted shortly thereafter.
 	\item The date and time of candidate speeches will be announced by a member of the Executive Board at least five (5) days prior to the event. 
 		All Active Members are expected to attend candidate speeches in accordance with \ref{Expectations of House Members}.
-		If a member cannot attend due to a scheduling conflict, they may provide a reason for their absence to the Evaluations Director, who will record the reason with the absence.
+		If a member cannot attend due to a scheduling conflict, they may provide a reason for their absence to the Evals Director, who will record the reason with the absence.
 	\item Each candidate will be given an equal amount of time before the House to present their platform of candidacy.
 	\item Ballots will then be distributed and voting will be open for a minimum of a forty-eight hour period.
 		The Ballots will list, in random order, all of the candidates who are qualified for a given office with a means to indicate the selection of one of the candidates.
 		In addition, an area will be provided to indicate a write-in selection of a candidate.
-	\item At the end of the voting period, the Chairperson will terminate voting by collecting the ballot box and the votes shall be counted as stated in \ref{Alternative Vote}.
+	\item At the end of the voting period, the Chair will terminate voting by collecting the ballot box and the votes shall be counted as stated in \ref{Alternative Vote}.
 	\item The winners are determined via the process described in \ref{Alternative Vote}.
 		A quorum of fifty-percent of the number of all members eligible to vote is required for the election to be official.
 		All winners are notified of their election.
@@ -880,14 +885,14 @@ The Executive Board may choose to select a current voting Executive Board member
 The selection process can be an informal appointment, or follow an election process similar to other voting Executive Board positions.
 
 \asection{Executive Board Resignations}
-An Executive Board Member may resign their position by submitting in writing the reason for resignation to the House Chairperson.
+An Executive Board Member may resign their position by submitting in writing the reason for resignation to the Chair.
 The resignation will be read at the following House Meeting and become effective at that time.
 The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time.
 Following a resignation, the Selection process, as defined in \ref{Selection}, of a replacement for the position vacated must begin within two weeks from when the resignation took place.
-To postpone such a Selection, the Chairperson may chair an Immediate Simple Majority Vote \ref{Immediate Vote} \ref{Simple Majority} during a House Meeting prior to the beginning of the Selection process to delay the Selection process by a specified amount of time.
+To postpone such a Selection, the Chair may call for an Immediate Simple Majority Vote \ref{Immediate Vote} \ref{Simple Majority} during a House Meeting prior to the beginning of the Selection process to delay the Selection process by a specified amount of time.
 
 \asection{Appointment of an Interim Director}
-The duties and responsibilities of a vacated office are assumed by the Chairperson or by an Active member that is appointed at the Chairperson's discretion until the new member takes office.
+The duties and responsibilities of a vacated office are assumed by the Chair or by an Active member that is appointed at the Chair's discretion until the new member takes office.
 The vote of a vacated Executive Board position shall be cast as an abstention in all Executive Board matters where this vote is required to be cast.
 
 \asection{Impeachment}
@@ -1022,14 +1027,14 @@ If the number of votes cast for the pass option equals the number of votes cast 
 \asubsection{With Multiple Options}
 If multiple options may pass, a tie does not present a problem.
 If only one option may pass, then the vote must be recast or tabled at the discretion of the Chair of the Vote.
-In the event of a tie in an Executive Board vote, the Chairperson may cast the tie-breaking vote.
+In the event of a tie in an Executive Board vote, the Chair may cast the tie-breaking vote.
 
 % ARTICLE VII - JUDICIAL
 \article{Judicial}
 The Executive Board may approve (by simple majority) a request (from a member) for a Judicial proceeding when an official clarification of the Constitution is required, there is a conflict among House Members, or a House interest needs resolution.
 \asection{Formation of a Judicial Board}
-A Judicial Board is made up of the Chairperson, the Evaluations director, and an additional voting member of the Executive Board chosen by a majority vote among the Executive Board.
-If either the Chairperson or Evaluations Director are deemed biased or unfit for a position on the Judicial Board, they will be replaced by another voting member of the Executive Board by means of a simple majority vote amongst the remaining Executive Board members.
+A Judicial Board is made up of the Chair, the Evals director, and an additional voting member of the Executive Board chosen by a majority vote among the Executive Board.
+If either the Chair or Evals Director are deemed biased or unfit for a position on the Judicial Board, they will be replaced by another voting member of the Executive Board by means of a simple majority vote amongst the remaining Executive Board members.
 \asection{Judicial Investigation}
 The Judicial Board will be responsible for making all necessary inquiries into the matter of the request brought to the Judicial Board.
 \asection{Judicial Ruling}

--- a/constitution.tex
+++ b/constitution.tex
@@ -141,11 +141,9 @@ Maintainers must be Active or Alumni in good standing.
 \asubsection{Maintainer Expectations}
 Maintainers are expected to:
 \begin{itemize}
-	\item Review changes to the Constitution for grammar, spelling, and internal consistency
-	\item Keep a public record of changes to the Constitution
-	\item Participate in discussion of proposals
-	\item Facilitate the creation of new changes to the Constitution by other members
 	\item Be knowledgeable about the Constitution
+	\item Participate in discussions of proposals and amendments
+	\item Review changes to the Constitution for grammar, spelling, and internal consistency
 \end{itemize}
 Failure to meet any of these expectations is grounds for revocation of Maintainer status by E-Board.
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -8,6 +8,7 @@
 \documentclass{article}
 \providecommand{\RevisionInfo}{}
 \usepackage{hyperref}
+
 % Reformat section titles
 \usepackage{titlesec}
 
@@ -44,6 +45,8 @@
 %\setcounter{secnumdepth}{5}
 \newcommand{\asubsubsection}[1]{\paragraph{#1} \label{#1}}
 \renewcommand{\theparagraph}{\arabic{section}.\Alph{subsection}.\arabic{subsubsection}.\Alph{paragraph}}
+
+\newcommand{\ampersand}{&}
 
 % Adding \a(sub){3,4}section during merge of bylaws and articles -- I feel _really_ dirty
 \setcounter{secnumdepth}{7}
@@ -91,20 +94,20 @@ The objectives of Computer Science House are:
 Many of the commonly used abbreviations will be listed here, and the abbreviations will be used throughout the rest of the document.
 
 \begin{enumerate}
-	\item Chair - Chariperson
-	\item Evals - Evaluations
-	\item R\&D - Research and Development
-	\item IMPs - House Improvements
+	\item Chairperson - Chair
+	\item Evaluations - Evals
+	\item Research and Development - R\&D
+	\item House Improvements - IMPs
 	\item Operational Communications - OpComm
-	\item History - House History
-	\item PR - Public Relations
+	\item House History - History
+	\item Public Relations - PR
 	\item Socials - Social
 	\item Financials - Financial
-	\item RTP - Root Type Person
-	\item Intro - Introductory
-	\item E-Board - Executive Board
-	\item ResLife - Residence Life
-	\item Maintainer - Constitutional Maintainer
+	\item Root Type Person - RTP
+	\item Introductory - Intro
+	\item Executive Board - E-Board
+	\item Residence Life - ResLife
+	\item Constitutional Maintainer - Maintainer
 \end{enumerate}
 
 
@@ -112,11 +115,11 @@ Many of the commonly used abbreviations will be listed here, and the abbreviatio
 \article{Constitutional Structure}
 
 \asection{House Charter}
-The House Charter is a document drafted by the department of Residence Life, setting down the guidelines within which this House operates and from which it derives its authority.
+The House Charter is a document drafted by ResLife, setting down the guidelines within which this House operates and from which it derives its authority.
 
 \asection{Constitution}
 The House Constitution is written and maintained by the House and defines the major aspects, goals, and governing structure of the house.
-It is reviewed annually by the Department of Residence Life.
+It is reviewed annually by ResLife.
 
 \asubsection{Non-Semantic Changes}
 There are two methods for non-semantic change to the Constitution.
@@ -149,18 +152,18 @@ Maintainers are expected to:
 	\item Facilitate the creation of new changes to the Constitution by other members
 	\item Be knowledgeable about the Constitution
 \end{itemize}
-Failure to meet any of these expectations is grounds for revocation of Maintainer status by the Executive Board.
+Failure to meet any of these expectations is grounds for revocation of Maintainer status by E-Board.
 
 \asubsection{Maintainer Resignations}
-Maintainers may resign at any time by notifying the current Executive Board and Maintainer group.
+Maintainers may resign at any time by notifying the current E-Board and Maintainer group.
 
 \asubsection{Maintainer Term}
-Maintainer status lasts until it is resigned, or until it is revoked by Executive Board vote.
+Maintainer status lasts until it is resigned, or until it is revoked by E-Board vote.
 If a Maintainer no longer satisfies \ref{Maintainer Qualifications}, they lose Maintainer status.
 
 \asubsection{Maintainer Selection}
-Any member may nominate a qualified member for Maintainer status to the Executive Board for consideration.
-The Executive Board may choose to approve or reject the nomination by Simple Majority vote.
+Any member may nominate a qualified member for Maintainer status to E-Board for consideration.
+E-Board may choose to approve or reject the nomination by Simple Majority vote.
 
 % ARTICLE III - GENERAL OPERATIONS OF THE HOUSE
 \article{General Operations of the House}
@@ -187,27 +190,27 @@ When describing the different memberships available, the following terms are use
 
 \asection{Introductory Membership}
 \asubsection{Introductory Membership Qualifications}
-Introductory Membership is open to all students at the Rochester Institute of Technology.
+Intro Membership is open to all RIT students.
 \asubsection{Introductory Membership Selection}
 Applicants notify the House of their interest in membership by submitting an application to the Evals Director.
 They must then undergo the selection process as defined in \ref{Selection Processes}.
 \asubsection{Introductory Membership Expectations}
-Introductory members are expected to meet all the requirements of the Introductory Process, as described in \ref{Expectations of an Introductory Member}.
+Intro members are expected to meet all the requirements of the Intro Process, as described in \ref{Expectations of an Introductory Member}.
 \asubsection{Introductory Membership Privileges}
-Introductory members receive the right to use Computer Science House facilities, to attend House functions, and to have housing priority over all persons who are not Computer Science House members.
+Intro members receive the right to use Computer Science House facilities, to attend House functions, and to have housing priority over all persons who are not Computer Science House members.
 \asubsection{Introductory Membership Evaluations}
-Introductory members are evaluated on their performance during the introductory period.
-The introductory evals process is described in \ref{Introductory Evaluation}.
+Intro members are evaluated on their performance during the intro period.
+The intro evals process is described in \ref{Introductory Evaluation}.
 \asubsection{Introductory Membership Leave of Absence}
-After completion of the Introductory Packet, an Introductory member may request a leave of absence through the process described in \ref{Leave of Absence}.
+After completion of the Intro Packet, an Intro member may request a leave of absence through the process described in \ref{Leave of Absence}.
 \asubsection{Introductory Membership Resignations}
-Introductory members may resign by submitting the request for termination of membership to the Chair, or Evals Director in writing before the completion of the introductory process.
+Intro members may resign by submitting the request for termination of membership to the Chair, or Evals Director in writing before the completion of the intro process.
 \asubsection{Introductory Membership Term}
-Introductory membership shall last until the end of the introductory process, at which time active membership is granted or membership is revoked.
+Intro membership shall last until the end of the intro process, at which time active membership is granted or membership is revoked.
 
 \asection{Active Membership}
 \asubsection{Active Membership Qualifications}
-Active Membership is open to all students currently enrolled at the Rochester Institute of Technology who have passed the Introductory Evals and their most recent Membership Evals.
+Active Membership is open to all current RIT students who have passed the Intro Evals and their most recent Membership Evals.
 \asubsection{Active Membership Selection}
 Qualifying members may self-select into Active Membership by paying dues to the Financial Director and notifying the Evals Director.
 \\*\\*
@@ -220,11 +223,11 @@ Active Members receive the right to:
 \begin{itemize}
 	\item Vote on all issues brought before the House
 	\item Reside on the House
-	\item Hold an Executive Board office on the House
+	\item Hold an E-Board office on the House
 	\item Use Computer Science House facilities
 	\item Attend Computer Science House functions
 	\item Receive priority for available housing on the House when returning from cooperative education
-	\item Guaranteed housing in compliance with the Residence Life policies regarding Special Interest Houses and the Housing Selection Process (if they have On-Floor status)
+	\item Guaranteed housing in compliance with ResLife policies regarding Special Interest Houses and the Housing Selection Process (if they have On-Floor status)
 \end{itemize}
 Active Members currently on co-op forfeit their right to vote on house issues, and likewise do not count towards quorum.
 Exceptions may be made at the discretion of the Evals Director.
@@ -252,7 +255,7 @@ Alumni Membership is open to all former Active members of Computer Science House
 Active members who depart house (i.e. resign) after passing the current operating session's Membership Evals are considered to be Alumni in good standing.
 \\*\\*
 Active members who depart house without passing the current operating session's Membership Evals are considered to be Alumni in bad standing.
-This may be appealed to the Executive Board in order to pursue a different outcome.
+This may be appealed to E-Board in order to pursue a different outcome.
 \asubsection{Alumni Membership Expectations}
 There are no expectations associated with the Alumni Membership status.
 \asubsection{Alumni Membership Privileges}
@@ -290,7 +293,7 @@ Honorary Membership shall last until the member resigns.
 \asubsection{Advisory Membership Qualifications}
 Advisory Membership is open to all members of the Rochester Institute of Technology professional, academic, or administrative staff.
 \asubsection{Advisory Membership Selection}
-The Executive Board may open nominations for Advisory Members.
+E-Board may open nominations for Advisory Members.
 The candidates then participate in the Advisory Selection Process as defined in \ref{Selection Process for Advisory Members}
 \asubsection{Advisory Membership Expectations}
 Advisors are encouraged to offer advice and assistance to the House in any capacity the Advisor is able to help.
@@ -313,45 +316,45 @@ Upon approval of a leave of absence request, the Evals Director is notified and 
 A member is also allowed to be physically present and also be on a leave of absence.
 \asubsection{Leave of Absence Request}
 A leave of absence request must include the following information about the member: name, email, phone number, start date, expected return date, and a reason for the leave.
-The request is then given to a staff member of Residence Life, excluding student employees, for approval.
+The request is then given to a ResLife staff member, excluding student employees, for approval.
 A leave of absence start date can be backdated.
-At no point does the Executive Board need to be informed of any details relating to the reason for the leave.
+At no point does E-Board need to be informed of any details relating to the reason for the leave.
 \asubsection{Leave of Absence Duration}
 A leave of absence can be granted for up to the length of one semester.
 \asubsection{Leave of Absence Extension}
 A leave of absence can be extended by submitting a new request.
 \asubsection{Leave of Absence Return}
 A member may return from a leave of absence whenever they choose to.
-When a member wishes to return, they must in writing notify a staff member of Residence Life, excluding student employees, to end their leave of absence.
+When a member wishes to return, they must in writing notify a ResLife staff member, excluding student employees, to end their leave of absence.
 \asubsection{Modified Evaluations}
 A member may request their evaluation period to be extended by the duration of the leave or to end of the Standard Operating Session, whichever comes first.
-\asubsection{Leave of Absence for an Executive Board Member}
-The duties and responsibilities of an Executive Board Member on leave are assumed using the process defined in Section \ref{Appointment of an Interim Director} until the member returns from their leave.
+\asubsection{Leave of Absence for an E-Board Member}
+The duties and responsibilities of an E-Board Member on leave are assumed using the process defined in Section \ref{Appointment of an Interim Director} until the member returns from their leave.
 Upon returning, the member may assume their position and the interim director is removed.
-If at any point the member's leave is determined by the Executive Board to be detrimental to the operations of house, any Executive Board member may propose a two-thirds vote amongst the Executive Board to require a resignation from the Member.
+If at any point the member's leave is determined by E-Board to be detrimental to the operations of house, any E-Board member may propose a two-thirds vote amongst E-Board to require a resignation from the Member.
 
 % ARTICLE V - EXECUTIVE BOARD
-\article{Executive Board}
-The Executive Board is the main governing body of the House.
+\article{E-Board}
+The E-Board is the main governing body of the House.
 Its purpose is to provide leadership and direction for the House, to oversee the day-to-day operations of the House, and to initiate and organize programs and projects for the House.
 It is composed of the seven permanent directors and the Chair.
 \\*\\*
-There is one permanent directorship for each major aspect of the government of the House and each one is chaired by an Executive Board member.
+There is one permanent directorship for each major aspect of the government of the House and each one is chaired by an E-Board member.
 Ad Hoc directorships are created on an as-needed basis.
 They are generally very task oriented and are chaired by a House member.
 A directorship has some jurisdiction in its area of interest and often is responsible for the day-to-day decisions regarding its area of interest.
 Any large expenditures or large effect decisions must be brought before the entire House
-\asection{Members of the Executive Board}
+\asection{Members of E-Board}
 \asubsection{Voting Members}
 \begin{itemize}
 	\item Evals Director
 	\item Social Director(s)
 	\item Financial Director
 	\item R\&D Director(s)
-	\item House Improvements Director
-	\item Operational Communications Director
-	\item House History Director
-	\item Public Relations Director
+	\item IMPs Director
+	\item OpComm Director
+	\item History Director
+	\item PR Director
 \end{itemize}
 \asubsection{Non-Voting Members}
 \begin{itemize}
@@ -359,23 +362,23 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item House Secretary
 	\item Ad Hoc Director(s)
 \end{itemize}
-\asection{Closed Executive Board}
-Closed Executive Board Meetings are open only to the Chair, Voting Members of the Executive Board, and those with the express permission of the Executive Board.
-A closed Executive Board meeting may be called at any time by any member of the Executive Board.
-However, the Chair and at least two-thirds of the Voting Members of the Executive Board must be present for the meeting to be called.
+\asection{Closed E-Board}
+Closed E-Board Meetings are open only to the Chair, Voting Members of E-Board, and those with the express permission of E-Board.
+A closed E-Board meeting may be called at any time by any member of E-Board.
+However, the Chair and at least two-thirds of the Voting Members of E-Board must be present for the meeting to be called.
 
 \asection{Responsibilities}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
-\asubsection{Responsibilities of the Executive Board}
+\asubsection{Responsibilities of E-Board}
 \begin{enumerate}
 	\item To hold a weekly meeting specific to their responsibilities and submit notes to the House
-	\item To meet, as an Executive Board, at least weekly during the Standard Operating Session, as defined in \ref{Standard Operating Session} to discuss and report the operations of the House
+	\item To meet, as an E-Board, at least weekly during the Standard Operating Session, as defined in \ref{Standard Operating Session} to discuss and report the operations of the House
 	\item To report pertinent information to House members at the following House Meeting
-	\item To maintain records of the goals defined by each previous Executive Board
+	\item To maintain records of the goals defined by each previous E-Board
 	\item To act as a Judicial Board as defined in \ref{Judicial}
 	\item To review major projects, as defined in \ref{Expectations of House Members}
 	\item To make the final vote regarding conditionals and appeals as defined in \ref{Membership Evaluation}
-	\item To respect the privacy of House members confiding in the Executive Board, barring situations related to endangerment of oneself or others, sexual assault, or in the case of a Judicial Board
+	\item To respect the privacy of House members confiding in E-Board, barring situations related to endangerment of oneself or others, sexual assault, or in the case of a Judicial Board
 	\item To publish a document at the end of each semester to all Members stating House’s accomplishments of that semester
 	\item To review and update the Constitution at the end of each Standard Operating Session, as defined in \ref{Standard Operating Session}.
 		The constitution should remain up to date with current practices.
@@ -383,12 +386,12 @@ However, the Chair and at least two-thirds of the Voting Members of the Executiv
 
 \asubsection{Responsibilities of the Chair}
 \begin{enumerate}
-	\item To preside over Executive Board and House Meetings
-	\item To exercise general supervision over the operations of the Executive Board
+	\item To preside over E-Board and House Meetings
+	\item To exercise general supervision over the operations of E-Board
 	\item To exercise general supervision over regular House activities
 	\item To act as a liaison to the academic and administrative departments at RIT
 	\item To act as a part of a Judicial Board as defined in \ref{Judicial}
-	\item To cast tie-breaking vote in a split decision in an Executive Board vote
+	\item To cast tie-breaking vote in a split decision in an E-Board vote
 \end{enumerate}
 
 \asubsection{Responsibilities of the Evaluations Director}
@@ -397,7 +400,7 @@ However, the Chair and at least two-thirds of the Voting Members of the Executiv
 	\item To exercise general supervision over Evals operations
 	\item To oversee the screening, interviewing, and acceptance or rejection of prospective House members
 	\item To oversee the Semi-Annual Evals of current House members
-	\item To collaborate with the Residence Life Advisor to determine room change selection and any changes of membership residency
+	\item To collaborate with the ResLife Advisor to determine room change selection and any changes of membership residency
 	\item To act as a part of a Judicial Board as defined in \ref{Judicial}
 	\item To prepare the House for Open Houses, tours, and special events
 \end{enumerate}
@@ -410,13 +413,13 @@ However, the Chair and at least two-thirds of the Voting Members of the Executiv
 	\item To ensure that there is a variety of activities for House members to participate in throughout the academic year
 \end{enumerate}
 
-\asubsection{Responsibilities of the Public Relations Director}
+\asubsection{Responsibilities of the PR Director}
 \begin{enumerate}
-	\item To preside over Public Relations Directorship Meetings
+	\item To preside over PR Directorship Meetings
 	\item To operate House social media accounts intended to represent House as a whole
 	\item To oversee the organization, initiation, and execution of House philanthropic events
 	\item To preserve and improve the public image of House
-	\item To collaborate with other Executive Board members to organize, initiate, execute, and advertise any events that are intended to be attended by persons whom have never been Active Members
+	\item To collaborate with other E-Board members to organize, initiate, execute, and advertise any events that are intended to be attended by persons whom have never been Active Members
 
 \end{enumerate}
 
@@ -432,33 +435,33 @@ However, the Chair and at least two-thirds of the Voting Members of the Executiv
 	\item To oversee the planning and execution of fundraising events
 \end{enumerate}
 
-\asubsection{Responsibilities of the Research and Development Director}
+\subsubsection{Responsibilities of the R\&D Director}
 \begin{enumerate}
-	\item To preside over Research and Development Meetings in which House members are encouraged to bring ideas for projects
-	\item To exercise general supervision over Research and Development operations
+	\item To preside over R\&D Meetings in which House members are encouraged to bring ideas for projects
+	\item To exercise general supervision over R\&D operations
 	\item To oversee the planning, organization and construction of technical projects for the House's benefit
-	\item To collaborate with the Operational Communications Director in an attempt to fulfill the House's need for technical equipment
+	\item To collaborate with the OpComm Director in an attempt to fulfill the House's need for technical equipment
 	\item To provide seminars and tutorials to educate House members in technical areas
 \end{enumerate}
 
-\asubsection{Responsibilities of the House Improvements Director}
+\asubsection{Responsibilities of the IMPs Director}
 \begin{enumerate}
-	\item To preside over House Improvements Meetings
-	\item To exercise general supervision over the House Improvements operations
+	\item To preside over IMPs Meetings
+	\item To exercise general supervision over the IMPs operations
 	\item To oversee the organization and construction of physical improvements to the House
 	\item To oversee the general maintenance of the appearance of the House
 \end{enumerate}
 
-\asubsection{Responsibilities of the Operational Communications Director}
+\asubsection{Responsibilities of the OpComm Director}
 \begin{enumerate}
-	\item To represent the Root Type Persons at Executive Board Meetings and at House Meetings
-	\item To report the status of the House computer systems and network to the Executive Board and House members
+	\item To represent the RTPs at E-Board Meetings and at House Meetings
+	\item To report the status of the House computer systems and network to E-Board and House members
 \end{enumerate}
 
-\asubsection{Responsibilities of the House History Director}
+\asubsection{Responsibilities of the History Director}
 \begin{enumerate}
-	\item To preside over House History Meetings
-	\item To exercise general supervision over the House History operations
+	\item To preside over History Meetings
+	\item To exercise general supervision over the History operations
 	\item To maintain, uphold, and promote house traditions
 	\item To collaborate with the Social Director(s) to ensure that all the Active, Alumni, and Advisory Members are informed of upcoming events
 	\item To oversee the production and distribution of a semi-annual newsletter
@@ -467,11 +470,11 @@ However, the Chair and at least two-thirds of the Voting Members of the Executiv
 
 \asubsection{Responsibilities of the House Secretary}
 \begin{enumerate}
-	\item To ensure that minutes are recorded and posted for Executive Board Meetings
+	\item To ensure that minutes are recorded and posted for E-Board Meetings
 	\item To ensure that minutes are recorded and posted for House Meetings
-	\item To oversee the maintenance of Executive Board records and documents
-	\item To provide administrative assistance to the Executive Board
-	\item To record all votes cast during House Meetings and Open Executive Board Meetings
+	\item To oversee the maintenance of E-Board records and documents
+	\item To provide administrative assistance to E-Board
+	\item To record all votes cast during House Meetings and Open E-Board Meetings
 \end{enumerate}
 
 \asubsection{Responsibilities of Ad Hoc Directorships}
@@ -485,7 +488,7 @@ However, the Chair and at least two-thirds of the Voting Members of the Executiv
 \asubsubsection{Amount of House Dues}
 The amount of dues for Active Members will be eighty dollars (\$80.00) per Academic Semester.
 \asubsubsection{Collection of House Dues}
-The collection period of house dues will be decided in conjunction with The Center for Residence Life and Housing Operations.
+The collection period of house dues will be decided in conjunction with the ResLife and Housing departments.
 During the dues collection period, dues for on-floor members (for both semesters) are collected through the member’s RIT bill.
 Dues for off-floor members are to be collected during this period as well by the Financial Director.
 For any member who moves on or off-floor during the year, any difference between dues paid and dues owed should be collected.
@@ -493,10 +496,10 @@ Dues for any alumnus/alumnae in good standing are to be collected when intention
 \asubsubsubsection{Rules for Giving Exceptions and Exemptions for House Dues}
 If a member is unable to pay dues upon request, they may appeal their situation to the Financial Director.
 If the Financial Director deems their situation appropriate, they may grant specific extensions or reductions of the member's payment as they see fit.
-If the Financial Director deems their situation inappropriate for extension, the member may appeal to the Executive Board.
-If the Executive Board disagrees with the Financial Director, the Executive Board may reduce the required payment or extend the payment deadline.
-If the Executive Board agrees with the Financial director, the member’s payment is considered delinquent and the member’s privileges are revoked until payment can be made.
-In the case the Financial Director or Executive Board decides the situation is appropriate, the member's dues may be partially or fully excused, or the member may be given additional time to pay their dues. 
+If the Financial Director deems their situation inappropriate for extension, the member may appeal to E-Board.
+If E-Board disagrees with the Financial Director, E-Board may reduce the required payment or extend the payment deadline.
+If E-Board agrees with the Financial director, the member’s payment is considered delinquent and the member’s privileges are revoked until payment can be made.
+In the case the Financial Director or E-Board decides the situation is appropriate, the member's dues may be partially or fully excused, or the member may be given additional time to pay their dues. 
 Additional time and reduction of dues may both be given to a member in an appropriate situation.
 All dues must be collected in full before the annual membership evals (\ref{Membership Evaluation}).
 After this date, dues collection is suspended until the start of the next academic year.
@@ -507,19 +510,19 @@ After this date, dues collection is suspended until the start of the next academ
 Directorship Name & Percentage of Dues \\
 \hline
 \hline
-Operational Communications & 20\% \\
+OpComm & 20\% \\
 \hline
 Evals & 5\% \\
 \hline
-House History & 10\% \\
+History & 10\% \\
 \hline
-House Improvements & 15\% \\
+IMPs & 15\% \\
 \hline
-Research and Development & 20\% \\
+R\&D & 20\% \\
 \hline
 Social & 20\% \\
 \hline
-Public Relations & 5\% \\
+PR & 5\% \\
 \hline
 Accumulated & 5\% \\
 \hline
@@ -550,27 +553,27 @@ Funds allocated for a project not spent by the end of the Standard Operating Ses
 % BY-LAW IV - OPERATIONS OF THE EVALUATIONS DIRECTORSHIP
 \asubsection{Operations of the Evaluations Directorship}
 \asubsubsection{The Introductory Process}
-The Introductory Process is designed to provide an easy means for Introductory Members to meet existing House members, learn House history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
+The Intro Process is designed to provide an easy means for Intro Members to meet existing House members, learn history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
 \asubsubsubsection{The Evaluation Period}
 The Process will occur either once or twice per semester, and will last for six (6) weeks.
 The Process shall be initiated by the Evals Director during either the first and second week of each semester.
-The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
-If an Introductory Process is extended, the Introductory Evaluation shall occur at the termination of the extended Process, which may be outside of the period defined in \ref{Introductory Evaluation}.
-If deemed necessary by the Evals Director, or by an Executive Board simple majority vote, the second intro process must begin within nine (9) days of the first process ending.
-If a second Introductory Process is approved, the Evals Director may initiate a new Introductory Packet within the first or second week of the Introductory Process.
+E-Board may hold a closed ballot Simple Majority vote to extend the Intro Process or the Intro Packet.
+If an Intro Process is extended, the Introductory Evaluation shall occur at the termination of the extended Process, which may be outside of the period defined in \ref{Introductory Evaluation}.
+If deemed necessary by the Evals Director, or by an E-Board simple majority vote, the second intro process must begin within nine (9) days of the first process ending.
+If a second Intro Process is approved, the Evals Director may initiate a new Intro Packet within the first or second week of the Intro Process.
 \asubsubsubsection{The Introductory Packet}
-Each Introductory Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active Members who have passed a Membership Evals, all Active Resident Members, all Introductory Resident Members, and ten (10) of any combination of the following:
+Each Intro Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active Members who have passed a Membership Evals, all Active Resident Members, all Resident Intro Members, and ten (10) of any combination of the following:
 \begin{itemize}
 	\item Alumni members
 	\item Honorary members
 	\item Advisory members
 \end{itemize}
-At the discretion of the Evals Director, any Introductory Packet may be extended to accommodate extenuating circumstances.
+At the discretion of the Evals Director, any Intro Packet may be extended to accommodate extenuating circumstances.
 \asubsubsubsection{Expectations of an Introductory Member}
-Before the end of the Process, an Introductory Member is expected to:
+Before the end of the Process, an Intro Member is expected to:
 \begin{itemize}
 \item Attend all House meetings during the process
-\item Complete the Introductory Packet
+\item Complete the Intro Packet
 \item Attend at least one House directorship meeting for each week of the process (including permanent and Ad Hoc directorship meetings)
 \item Attend at least one House social event during the process
 \item Attend at least two seminars relating to computing or electronics
@@ -578,18 +581,18 @@ Before the end of the Process, an Introductory Member is expected to:
 \end{itemize}
 
 \asubsubsubsection{Introductory Evaluation}
-The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of full Resident or Non-Resident Membership.
+The Introductory Evaluation is the process by which House chooses which Intro Members to extend an offer of full Resident or Non-Resident Membership.
 Occurs at the conclusion of the final week of the Process.
 
 \asubsubsubsubsection{Voting}
-On a member by member basis, this evaluation process determines if each Introductory member has successfully completed the Introductory Process requirements \ref{Expectations of an Introductory Member}.
+On a member by member basis, this evaluation process determines if each Intro member has successfully completed the Intro Process requirements \ref{Expectations of an Introductory Member}.
 A Simple Majority vote with a quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.
 In order for an Active Member to be counted as a Possible Vote they must meet the requirements outlined in \ref{Expectations of Voting Members}.
 Neither absentee nor proxy votes are allowed.
 House may choose any of the Outcomes for each member.
 \asubsubsubsubsection{Expectations of Voting Members}
 The following requirements must be met by the beginning of the Introductory Evals for an Active Member to be allowed to vote. 
-Any of these requirements may be waived by the Evals Director or a simple majority vote by the Executive Board
+Any of these requirements may be waived by the Evals Director or a simple majority vote by E-Board
 \begin{itemize}
 \item Attend all House meetings during the process
 \item Attend at least one House directorship meeting for each week of the process (including permanent and Ad Hoc directorship meetings)
@@ -600,13 +603,13 @@ Any of these requirements may be waived by the Evals Director or a simple majori
 \asubsubsubsubsection{Outcomes}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \begin{enumerate}
-	\item Introductory Members may be offered Active Membership (\ref{Active Membership}) provided they meet the requirements described in \ref{Expectations of an Introductory Member}, at the discretion of House.
-	\item If an Introductory Member fails to meet the requirements, their membership will be revoked.
-		In addition, the participant is asked to find alternative housing as soon as possible in accordance with all applicable Residence Life policies regarding room changes.
-	\item An Introductory member may be given a conditional to complete as a means of making up for missing requirements.
+	\item Intro Members may be offered Active Membership (\ref{Active Membership}) provided they meet the requirements described in \ref{Expectations of an Introductory Member}, at the discretion of House.
+	\item If an Intro Member fails to meet the requirements, their membership will be revoked.
+		In addition, the participant is asked to find alternative housing as soon as possible in accordance with all applicable ResLife policies regarding room changes.
+	\item An Intro member may be given a conditional to complete as a means of making up for missing requirements.
 		A conditional may be proposed by any member present at the Introductory Evals and, if it is approved by the Evals Director, is then voted on by House.
 		Each conditional consists of a set of additional requirements and a deadline for completing them.
-		When the deadline expires, the conditional will be brought before the Executive Board who will assess its completeness.
+		When the deadline expires, the conditional will be brought before E-Board who will assess its completeness.
 		A conditional member who does not meet these additional requirements forfeits membership.
 \end{enumerate}
 \asubsubsection{Selection Processes}
@@ -616,42 +619,42 @@ Any of these requirements may be waived by the Evals Director or a simple majori
 	\item The applicant submits an application to the Evals Director for review.
 	\item The applicant participates in an informal interview with exactly three current Active, Alumni, or Honorary Members.
 	\item The application materials are then reviewed at an Evals meeting.
-	Then a simple majority vote, of attending members, is held on whether or not to accept the person as an Introductory Member.
+	Then a simple majority vote, of attending members, is held on whether or not to accept the person as an Intro Member.
 \end{enumerate}
-Note: Most membership privileges do not initiate until successful completion of the introductory process.
+Note: Most membership privileges do not initiate until successful completion of the intro process.
 This means that until the member has passed the Introductory Evals, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
 The member does, however, have the right to use Computer Science House's facilities.
-The member is not required to pay dues during the Introductory Process.
+The member is not required to pay dues during the Intro Process.
 \\* \\*
 Additional Note: No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
 \asubsubsubsection{Selection Process for First Semester and Entering RIT Students}
 \begin{enumerate}
 	\item During Spring semester, the Evals Director selects a group of Active Members to form a Selections Committee.
-		The Selections Committee reviews applications and conducts interviews in accordance with the process prescribed by Residence Life.
-	\item A subset of applications will be selected to move onto the House Fall Semester, are granted full membership privileges (including On-Floor status), and must participate in the Introductory Process as defined in \ref{The Introductory Process}.
+		The Selections Committee reviews applications and conducts interviews in accordance with the process prescribed by ResLife.
+	\item A subset of applications will be selected to move onto the House Fall Semester, are granted full membership privileges (including On-Floor status), and must participate in the Intro Process as defined in \ref{The Introductory Process}.
 		An additional subset will be given Off-Floor status, but otherwise receive the same privileges and responsibilities.
 \end{enumerate}
-Note: Most membership privileges do not initiate until successful completion of the introductory process.
+Note: Most membership privileges do not initiate until successful completion of the intro process.
 This means that until the member has passed the Introductory Evals, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
 The member does, however, have the right to use Computer Science House's facilities.
-The member is not required to pay dues during the Introductory Process.
+The member is not required to pay dues during the Intro Process.
 \\* \\*
 Additional Note: No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
 \asubsubsubsection{Selection Process for Honorary Members}
 \begin{enumerate}
 	\item A House Member submits to the Evals Director a nomination for a person they feel is deserving of Honorary Membership.
 	\item The Evals Director performs some preliminary research on the candidate and presents the findings.
-	\item The Executive Board decides whether or not to present the nomination to the House for a secret ballot House vote.
-		If the Executive Board decides not to present the nomination to the House, the Selection Process ends and the candidate does not become an Honorary Member.
+	\item E-Board decides whether or not to present the nomination to the House for a secret ballot House vote.
+		If E-Board decides not to present the nomination to the House, the Selection Process ends and the candidate does not become an Honorary Member.
 	\item The nomination is presented at a House Meeting for discussion and a Two-Thirds vote, as described in \ref{Two-Thirds}.
 		Ballots are distributed and voting must remain open for a minimum of forty-eight hour period.
 	\item The candidate is notified of their selection as an Honorary Member and presented with the honor.
 \end{enumerate}
 \asubsubsubsection{Selection Process for Advisory Members}
 \begin{enumerate}
-	\item When there is a perceived need, the Executive Board may open nominations for Advisory Members.
+	\item When there is a perceived need, E-Board may open nominations for Advisory Members.
 		After an announcement at House Meeting, during a 72-hour period, any House Member may submit a nomination.
-	\item After the close of the nomination collection period, the Executive Board will arrange some means for the House to meet with the nominees.
+	\item After the close of the nomination collection period, E-Board will arrange some means for the House to meet with the nominees.
 	\item A discussion of the candidates will be held at the following House meeting.
 	\item Ballots are distributed for each nominee as a fifty-percent House vote defined in \ref{Fifty Percent}.
 		Voting must remain open for a minimum of a forty-eight hour period.
@@ -662,7 +665,7 @@ Additional Note: No hazing shall occur at any time during the Selection Process 
 During the academic year, a House member is evaluated by the Membership Evals.
 The Membership Evals is responsible for determining those individuals who will have the option to continue Active Membership in the following year.
 Semi-Annual Evals Meetings are open only to current Active Members.
-All Executive Board members are expected to attend the Semi-Annual Evals Meetings to assist in the evaluations of House members.
+All E-Board members are expected to attend the Semi-Annual Evals Meetings to assist in the evaluations of House members.
 \\* \\*
 At the beginning of any Evals Process listed herein, the Evals Director must read the sections of the Computer Science House Constitution used during the respective Evals Process.
 It is incumbent upon each House member to provide the Evals Director with whatever information they feel is necessary to ensure an accurate evaluation.
@@ -671,7 +674,7 @@ The Membership Evaluation process occurs once per academic year.
 It is performed as part of the Evals Process that takes place during the spring semester to comply with RIT Housing deadlines.
 \asubsubsubsubsection{Voting}
 Any Active Member who has completed all of the requirements as defined in \ref{Expectations of House Members} at the beginning of the Membership Evals passes their Membership Evals without being voted on or evaluated by the quorum.
-All Active Members who have not recieved an exemption from the Executive Board prior to the Membership Evals will be evaluated on a Member by Member basis by a quorum of Active Members.
+All Active Members who have not recieved an exemption from E-Board prior to the Membership Evals will be evaluated on a Member by Member basis by a quorum of Active Members.
 The Membership Evals shall hold members to the objective requirements defined in \ref{Expectations of House Members} and determine which members may continue as an Active Member in the following Standard Operating Session.
 Exceptions to the requirements may be made, as House may choose any of the Outcomes for each Member, even if the Member being evaluated has not completed all of their requirements.
 These requirements must be completed before the Membership Evals occurs.
@@ -690,24 +693,24 @@ A member may be given a conditional to complete as a means of making up for miss
 A conditional may be proposed by any member present at the Evaluation.
 If the conditional is approved by the Evals Director, it is then voted on by House.
 Each conditional consists of a set of additional requirements a deadline for completing them.
-When the deadline expires, the conditional will be brought before the Executive Board who will assess its completeness.
+When the deadline expires, the conditional will be brought before E-Board who will assess its completeness.
 A conditional member who does not meet these additional requirements will have failed the evaluation.
 \asubsubsubsection{Appeals Process}
 If a member disagrees with the outcome of any evaluation, (e.g. is not asked to return to the House for the following year) and wishes to appeal the decision, they may do so as stated in \ref{Appeals}.
 \\* \\*
-If the member is still unsatisfied after being heard by the Executive Board, the appeal may be brought to the attention of the ResLife Advisor.
+If the member is still unsatisfied after being heard by E-Board, the appeal may be brought to the attention of the ResLife Advisor.
 
 \asubsubsection{Expectations of House Members}
-Each member is required to pay House dues as stated in \ref{Collection of House Dues}, attend all House Meetings and Executive Board candidate speeches, and attend at least fifteen (15) of the House directorship meetings (including permanent and Ad Hoc directorship meetings) for each Academic Semester in which they are an Active Member.
+Each member is required to pay House dues as stated in \ref{Collection of House Dues}, attend all House Meetings and E-Board candidate speeches, and attend at least fifteen (15) of the House directorship meetings (including permanent and Ad Hoc directorship meetings) for each Academic Semester in which they are an Active Member.
 \\* \\*
 The member must participate significantly in at least one major project during the academic year.
-The member is required to submit a description for this major project to the Executive Board for approval.
+The member is required to submit a description for this major project to E-Board for approval.
 As an option to this requirement, the member may instead assist on a large number of House activities and projects.
 However, it is to be understood in advance by the member that this option requires a great deal of participation throughout the year.
-This participation will be evaluated by the Executive Board.
+This participation will be evaluated by E-Board.
 
 \asubsubsection{Housing Status}
-All Active and Introductory Members have a housing status.
+All Active and Intro Members have a housing status.
 This status indicates their right to priority housing on the floor.
 Any Alumni Member in good standing will maintain their previous On Floor status upon a return to Active membership.
 \asubsubsubsection{On-Floor Status}
@@ -730,48 +733,48 @@ In the event of a tie, the members will be approached simultaneously and if they
 If that House member declines the option, it will be offered to the member with the next highest Housing Priority.
 This process continues until a member selects to move into the single room.
 Once in a single room, a House member retains the assignment until voluntarily giving it up.
-It should be noted that members selecting this option must agree to any additional charges applied by the Department of Residence Life for residing in a single room.
+It should be noted that members selecting this option must agree to any additional charges applied by ResLife for residing in a single room.
 \asubsubsubsection{Double Rooms as Single rooms}
 During the third week of each semester, if there is no waiting list for residency on the House, any vacant rooms will be offered to House members as single rooms assignments according to the method as described in \ref{Single Room Assignments}.
 It should be noted that this does not mean members will be relocated into empty spaces so that the member with top priority is offered the single.
 This only applies if there is a totally vacant room.
 
-\asubsection{Operations of the Operational Communications Directorship}
-The Operational Communications Directorship is responsible for overseeing the implementation of maintenance and upgrades to the House Computer Systems Network.
+\asubsection{Operations of the OpComm Directorship}
+The OpComm Directorship is responsible for overseeing the implementation of maintenance and upgrades to the House Computer Systems Network.
 It is a self-governing committee making decisions by a simple majority vote.
-Membership is composed of all Root Type Persons.
+Membership is composed of all RTPs.
 
-\asubsubsection{Selection of a Root Type Person}
+\asubsubsection{Selection of an RTP}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \begin{enumerate}
-	\item Nominations are taken from the Root Type Persons and Prior Root Type Persons meeting the selection criteria in \ref{Qualifications of a Root Type Person}.
+	\item Nominations are taken from the RTPs and Prior RTPs meeting the selection criteria in \ref{Qualifications of an RTP}.
 	\item Each candidate is given a minimum of twenty-four hour period to accept or decline the nomination.
-	\item A list of all nominees who have accepted is presented to the Executive Board for approval.
-		This Executive Board Meeting is closed to the Executive Board Members, Root Type Persons, and House members with explicit invitation from the Executive Board.
-	\item If an Executive Board member is a candidate for the office in discussion, the member is absent and their vote is abstained.
-		A simple majority Executive Board vote, as described in \ref{Simple Majority}, is taken to determine whether the nominations of the Root Type Persons are accepted.
+	\item A list of all nominees who have accepted is presented to E-Board for approval.
+		This E-Board Meeting is closed to E-Board Members, RTPs, and House members with explicit invitation from the E-Board.
+	\item If an E-Board member is a candidate for the office in discussion, the member is absent and their vote is abstained.
+		A simple majority E-Board vote, as described in \ref{Simple Majority}, is taken to determine whether the nominations of the RTPs are accepted.
 \end{enumerate}
 
-\asubsubsection{Qualifications of a Root Type Person}
+\asubsubsection{Qualifications of an RTP}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \begin{enumerate}
 	\item Candidates must have been an On-Floor Active Member in good standing within the last twelve months, or been an Off-Floor Active Member and have lived on the floor within the last twelve months.
-	\item Candidates may be granted an exemption by current Root Type Persons.
-		Such an exemption may be withdrawn at any time by the current Root Type Persons.
-	\item Prior Root Type Persons are those members who are no longer current Active Members and have not been granted an extension by the current Root Type Persons.
-		Prior Root Type Persons are not guaranteed access to the current root passwords and other authentication tokens.
-	\item The current Root Type Persons may from time to time draft rules and regulations specifying the rights and privileges of Prior Root Type Persons.
+	\item Candidates may be granted an exemption by current RTPs.
+		Such an exemption may be withdrawn at any time by the current RTPs.
+	\item Prior RTPs are those members who are no longer current Active Members and have not been granted an extension by the current RTPs.
+		Prior RTPs are not guaranteed access to the current root passwords and other authentication tokens.
+	\item The current Root Type Persons may from time to time draft rules and regulations specifying the rights and privileges of Prior RTPs.
 \end{enumerate}
 
 \asubsubsection{Creation of Accounts}
-Root Type Persons have the authority to manage user accounts for House systems.
-Before introductory, active, or alumni members may receive an account they must:
+RTPs have the authority to manage user accounts for House systems.
+Before intro, active, or alumni members may receive an account they must:
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \begin{enumerate}
 	\item Sign the Code of Conduct sheets pertaining to the responsible utilization of Computer Science House and Rochester Institute of Technology facilities.
-	\item Obtain greater than or equal to 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evals) in the Introductory Packet or successfully complete Introductory Evals.
+	\item Obtain greater than or equal to 60\% (rounded up to the nearest whole person) of required signatures (excluding those of Resident members who have not passed a Membership Evals) in the Intro Packet or successfully complete Introductory Evals.
 \end{enumerate}
-Accounts for honorary and advisory members may be created at the discretion of the Root Type Persons.
+Accounts for honorary and advisory members may be created at the discretion of the RTPs.
 
 \asubsubsection{Code of Conduct}
 The Code of Conduct located at \url{https://github.com/ComputerScienceHouse/CodeOfConduct} is the canonical Code of Conduct for Computer Science House accounts.
@@ -781,7 +784,7 @@ Members may sign a more recent revision of the Code of Conduct to update their a
 \asubsubsubsection{Changes}
 The following process is used for making changes to the Code of Conduct document.
 \begin{enumerate}
-	\item A Root Type Person drafts a change to the Code of Conduct and makes publicly available both the summary and difference file of the change.
+	\item An RTP drafts a change to the Code of Conduct and makes publicly available both the summary and difference file of the change.
 	\item The change is proposed at a House Meeting and is discussed at the same House Meeting.
 	\item The final proposal is presented at the next House Meeting and ballots are distributed for a Balloted House vote as described in \ref{Balloted Vote}.
 \end{enumerate}
@@ -793,19 +796,19 @@ The following process is used for making changes to the Code of Conduct document
 	\item Candidates must be Active Members during the term of office
 	\item Candidates must reside on floor during the term of office
 	\item Candidates must have at least one full semester of House membership as an Active Member
-	\item Elected or selected candidates may not hold a simultaneous voting Executive Board position, and must therefore resign their current position, or the position of Chair, should they be elected
+	\item Elected or selected candidates may not hold a simultaneous voting E-Board position, and must therefore resign their current position, or the position of Chair, should they be elected
 \end{enumerate}
-\asubsection{Qualifications to be the Social Director(s), Financial Director, Research and Development Director(s), House Improvements Director, House History Director, Public Relations Director}
+\subsubsection{Qualifications to be the Social Director(s), Financial Director, R\&D Director(s), IMPs Director, History Director, PR Director}
 \begin{enumerate}
 	\item Candidates must be Active Members during the term of office
 	\item Candidates must have at least one full semester of House membership as an Active Member
-	\item Elected or selected candidates may not hold two simultaneous voting Executive Board positions, and must therefore resign their current position or decline a second position should they be elected or selected to a second voting position
+	\item Elected or selected candidates may not hold two simultaneous voting E-Board positions, and must therefore resign their current position or decline a second position should they be elected or selected to a second voting position
 \end{enumerate}
-\asubsection{Qualifications to be the Operational Communications Director}
+\asubsection{Qualifications to be the OpComm Director}
 \begin{enumerate}
-	\item Candidates must be a current Root Type Person \ref{Operations of the Operational Communications Directorship}.
+	\item Candidates must be a current RTP \ref{Operations of the OpComm Directorship}.
 	\item Candidates must be a current Active Member.
-	\item A Root Type Person cannot be the director if they currently hold any other voting Executive Board Position.
+	\item An RTP cannot be the director if they currently hold any other voting E-Board Position.
 \end{enumerate}
 
 \asubsection{Qualifications to be the House Secretary or an Ad Hoc Director}
@@ -815,43 +818,43 @@ The following process is used for making changes to the Code of Conduct document
 
 \asubsection{Waiving of Qualifications}
 \begin{enumerate}
-  \item House may choose to waive the following subset of the Qualifications for Executive Board positions (defined under \ref{Qualifications}) for all Candidates:
+  \item House may choose to waive the following subset of the Qualifications for E-Board positions (defined under \ref{Qualifications}) for all Candidates:
     \begin{enumerate}
       \item Candidates must reside on floor during the term of office.
       \item Candidates must have at least one full semester of House membership as an Active Member.
-      \item Social and Research and Development are the only voting Executive Board positions that allow for Dual Directorship.
+      \item Social and R\&D are the only voting E-Board positions that allow for Dual Directorship.
     \end{enumerate}
-  \item When a waiver is proposed, the Chair of the Vote shall state which Executive Board position and Qualification is being voted upon, and any nominated Candidates not qualified under \ref{Qualifications} who would become qualified if the waiver passes.
+  \item When a waiver is proposed, the Chair of the Vote shall state which E-Board position and Qualification is being voted upon, and any nominated Candidates not qualified under \ref{Qualifications} who would become qualified if the waiver passes.
   \item A Three-Quarters Immediate Vote, as defined in \ref{Three-Quarters} and \ref{Immediate Vote}, is then taken to determine whether the proposed waiver shall take effect.
-  \item Each vote to waive a Qualification must only apply to a single Qualification for a single Executive Board position.
-  \item Waivers always apply to all Candidates for the Executive Board position.
+  \item Each vote to waive a Qualification must only apply to a single Qualification for a single E-Board position.
+  \item Waivers always apply to all Candidates for the E-Board position.
 \end{enumerate}
 
 \asection{Selection}
 \asubsection{Dual Directorship}
-Social and Research and Development are the only voting Executive Board positions that allow for Dual Directorship.
+Social and R\&D are the only voting E-Board positions that allow for Dual Directorship.
 If two candidates elect to run as a Dual Directorship, their names are placed together on a single line of the election ballot.
 If they are also nominated as a normal directorship or as a dual directorship with another House member, their votes are not cumulative.
 Each different nomination must be a separate entry on the election ballot.
-Non-voting Executive Board positions (i.e. Ad Hoc Directors) are not restricted to single or dual directorship.
+Non-voting E-Board positions (i.e. Ad Hoc Directors) are not restricted to single or dual directorship.
 
 The following special cases cover the operation of a dual directorship:
 \begin{itemize}
 	\item If one of the members in a dual directorship resigns the directorship, or for any other reason ends the term of office, the other member in the dual directorship must also step down and the office becomes vacated.
-		The vacated office is then handled like any other vacated office; see \ref{Executive Board Resignations}.
-	\item During an official Executive Board Vote, each dual directorship member's vote counts for one-half vote in the tallying of votes.
+		The vacated office is then handled like any other vacated office; see \ref{E-Board Resignations}.
+	\item During an official E-Board Vote, each dual directorship member's vote counts for one-half vote in the tallying of votes.
 		The members of the dual directorship need not vote the same way in a vote.
-	\item A member of a dual directorship may not hold any other Executive Board position.
+	\item A member of a dual directorship may not hold any other E-Board position.
 	\item When attendance requirements call for the dual directorship position to be present, both dual directorship members are to fulfill the requirements.
 \end{itemize}
-\asubsection{Selection of the Chair, Evals Director, Social Director(s), Financial Director, House Improvements Director, House History Director, Research and Development Director(s), Public Relations Director}
+\subsubsection{Selection of the Chair, Evals Director, Social Director(s), Financial Director, IMPs Director, History Director,  R\&D Director(s), PR Director}
 \begin{enumerate}
-	\item The opening of the Executive Board position(s) is announced at a House meeting and nominations for the position are taken for a minimum of a seventy-two hour period.
+	\item The opening of the E-Board position(s) is announced at a House meeting and nominations for the position are taken for a minimum of a seventy-two hour period.
 		Any House member may nominate any member or pair of members where appropriate for a Directorship.
 	\item The candidates will be notified of their nomination.
 		Each candidate is given a minimum of twenty-four hour period to accept or decline the nomination.
 		A list of all nominees who have accepted their nominations will be posted shortly thereafter.
-	\item The date and time of candidate speeches will be announced by a member of the Executive Board at least five (5) days prior to the event. 
+	\item The date and time of candidate speeches will be announced by a member of E-Board at least five (5) days prior to the event. 
 		All Active Members are expected to attend candidate speeches in accordance with \ref{Expectations of House Members}.
 		If a member cannot attend due to a scheduling conflict, they may provide a reason for their absence to the Evals Director, who will record the reason with the absence.
 	\item Each candidate will be given an equal amount of time before the House to present their platform of candidacy.
@@ -866,26 +869,26 @@ The following special cases cover the operation of a dual directorship:
 		If not, the winner will assume office at the end of the current term (\ref{Term}).
 		Any office whose winner declines the election, or whose winner does not fulfill the requirements of the elected office, shall have their votes redistributed in the same process as a loser in \ref{Alternative Vote}.
 \end{enumerate}
-\asubsection{Selection of the Operational Communications Director}
+\asubsection{Selection of the OpComm Director}
 \begin{enumerate}
-	\item A candidate for the Operational Communications Directorship shall be chosen by the current Root Type Persons.
+	\item A candidate for the OpComm Directorship shall be chosen by the current RTPs.
 	\item The candidate is given a minimum of twenty-four hours to accept or decline the nomination.
-	\item The candidate is presented to the Executive Board for approval.
-		This Executive Board meeting is closed to the Executive Board Members, Root Type Persons, and House members with explicit invitation from the Executive Board.
-	\item All current Executive Board Voting Members must be present during the discussion and voting period unless that member is a candidate for the position, in which case the member is absent and their vote is abstained.
-		A simple majority Executive Board vote, as described in \ref{Simple Majority}, is taken to determine whether the candidate is selected for the position.
+	\item The candidate is presented to E-Board for approval.
+		This E-Board meeting is closed to the E-Board Members, RTPs, and House members with explicit invitation from E-Board.
+	\item All current Voting E-Board Members must be present during the discussion and voting period unless that member is a candidate for the position, in which case the member is absent and their vote is abstained.
+		A simple majority E-Board vote, as described in \ref{Simple Majority}, is taken to determine whether the candidate is selected for the position.
 \end{enumerate}
 \asubsection{Selection of Ad Hoc Directors}
 \begin{enumerate}
-	\item When the Executive Board or a group of House members feels an Ad Hoc Directorship is necessary, they present their plans to the Executive Board and the Executive Board decides by simple majority vote whether directorship status is granted.
+	\item When E-Board or a group of House members feels an Ad Hoc Directorship is necessary, they present their plans to E-Board and E-Board decides by simple majority vote whether directorship status is granted.
 	\item When the Ad Hoc Directorship is granted status, a director is appointed, and duties, budgetary, and membership considerations are defined.
 \end{enumerate}
 \asubsection{Selection of the House Secretary}
-The Executive Board may choose to select a current voting Executive Board member, or to select any interested Active member, as House Secretary.
-The selection process can be an informal appointment, or follow an election process similar to other voting Executive Board positions.
+E-Board may choose to select a current voting E-Board member, or to select any interested Active member, as House Secretary.
+The selection process can be an informal appointment, or follow an election process similar to other voting E-Board positions.
 
-\asection{Executive Board Resignations}
-An Executive Board Member may resign their position by submitting in writing the reason for resignation to the Chair.
+\asection{E-Board Resignations}
+An E-Board Member may resign their position by submitting in writing the reason for resignation to the Chair.
 The resignation will be read at the following House Meeting and become effective at that time.
 The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time.
 Following a resignation, the Selection process, as defined in \ref{Selection}, of a replacement for the position vacated must begin within two weeks from when the resignation took place.
@@ -893,31 +896,31 @@ To postpone such a Selection, the Chair may call for an Immediate Simple Majorit
 
 \asection{Appointment of an Interim Director}
 The duties and responsibilities of a vacated office are assumed by the Chair or by an Active member that is appointed at the Chair's discretion until the new member takes office.
-The vote of a vacated Executive Board position shall be cast as an abstention in all Executive Board matters where this vote is required to be cast.
+The vote of a vacated E-Board position shall be cast as an abstention in all E-Board matters where this vote is required to be cast.
 
 \asection{Impeachment}
 \begin{enumerate}
-	\item Impeachment of any Executive Board Member may be initiated by petition, in writing, consisting of a minimum number of signatures of current House members equaling or exceeding one-third the Number of Possible Votes as defined in \ref{Total Number of Possible Votes}.
-	\item The impeachment petition is then presented at an Executive Board Meeting.
-		The member(s) initiating the petition present their case to the Executive Board.
-		The Executive Board then questions the accused member of the allegations.
-	\item The Executive Board votes on the impeachment petition, with all voting members present except the accused member who must be absent and whose vote counts as an abstention, to determine if the allegations stated in the petition are legitimate grounds for impeachment.
-		If the majority of Executive Board votes are negative, the petition and impeachment proceedings are dismissed.
+	\item Impeachment of any E-Board Member may be initiated by petition, in writing, consisting of a minimum number of signatures of current House members equaling or exceeding one-third the Number of Possible Votes as defined in \ref{Total Number of Possible Votes}.
+	\item The impeachment petition is then presented at an E-Board Meeting.
+		The member(s) initiating the petition present their case to E-Board.
+		E-Board then questions the accused member of the allegations.
+	\item E-Board votes on the impeachment petition, with all voting members present except the accused member who must be absent and whose vote counts as an abstention, to determine if the allegations stated in the petition are legitimate grounds for impeachment.
+		If the majority of E-Board votes are negative, the petition and impeachment proceedings are dismissed.
 		This vote may be overridden by an impeachment petition consisting of the grounds for impeachment and a minimum of number of signatures of current House members equaling or exceeding two-thirds the number of all House members currently eligible to vote.
-	\item If the majority of the Executive Board votes are positive, or the negative vote was overridden, the petition is presented at the following House Meeting and the accused and accuser(s) again present their cases.
+	\item If the majority of the E-Board votes are positive, or the negative vote was overridden, the petition is presented at the following House Meeting and the accused and accuser(s) again present their cases.
 	\item Ballots will then be distributed and a secret ballot House vote shall be held for a minimum of a forty-eight hour period to determine whether or not the member should be removed from office.
 		Votes shall be collected and counted as described in \ref{Balloted Vote}.
 	\item A quorum of two-thirds of the Total Number of Possible Votes is necessary for the vote to be official.
 		A vote equaling or exceeding two-thirds the number of all ballots cast is necessary for the accused officer to be removed from office.
 		If a quorum cannot be reached after two attempts, or the percentage of affirmative votes does not equal or exceed the minimum, impeachment proceedings are dismissed.
 	\item If the percentage of affirmative votes equals or exceeds the minimum the impeached officer is relinquished of their position and any benefits thereof and this position is treated like any other vacated position.
-		A new selection and interim duty fulfillment procedure is followed similar to that of a resignation; see \ref{Executive Board Resignations}.
-	\item House Secretary can be impeached according to the above process, or may be dismissed by a Simple Majority vote of the Executive Board.
+		A new selection and interim duty fulfillment procedure is followed similar to that of a resignation; see \ref{E-Board Resignations}.
+	\item House Secretary can be impeached according to the above process, or may be dismissed by a Simple Majority vote of E-Board.
 \end{enumerate}
 
 \asection{Term}
 \begin{enumerate}
-\item The Election Process for the following year's Executive Board members shall begin in the middle of Spring semester.
+\item The Election Process for the following year's E-Board members shall begin in the middle of Spring semester.
 \item The newly selected officers shall begin their terms on June 1 of that year and their terms shall end on May 31 of the following year.
 \item The term of an officer will be abbreviated due to resignation, impeachment, or change in membership status.
 \item Officers elected or selected during the course of the year due to an abbreviated term of the previous officer shall hold office until the end of the normal term.
@@ -926,10 +929,10 @@ The vote of a vacated Executive Board position shall be cast as an abstention in
 \end{enumerate}
 
 \asection{Appeals}
-Decisions made by the Executive Board may be appealed and overturned.
-To initiate an appeal, a member must have the support of three voting members of the Executive Board, or a petition with the signatures of one-third of Active Members.
-After the appeal is presented, a Simple Majority vote is held by the Executive Board whether or not to overturn and reevaluate the decision.
-If the vote passes, the Executive Board may discuss and make a new ruling by another Simple Majority vote.
+Decisions made by E-Board may be appealed and overturned.
+To initiate an appeal, a member must have the support of three voting E-Board members, or a petition with the signatures of one-third of Active Members.
+After the appeal is presented, a Simple Majority vote is held by E-Board whether or not to overturn and reevaluate the decision.
+If the vote passes, E-Board may discuss and make a new ruling by another Simple Majority vote.
 
 % ARTICLE VI - VOTING
 \article{Voting}
@@ -1027,19 +1030,19 @@ If the number of votes cast for the pass option equals the number of votes cast 
 \asubsection{With Multiple Options}
 If multiple options may pass, a tie does not present a problem.
 If only one option may pass, then the vote must be recast or tabled at the discretion of the Chair of the Vote.
-In the event of a tie in an Executive Board vote, the Chair may cast the tie-breaking vote.
+In the event of a tie in an E-Board vote, the Chair may cast the tie-breaking vote.
 
 % ARTICLE VII - JUDICIAL
 \article{Judicial}
-The Executive Board may approve (by simple majority) a request (from a member) for a Judicial proceeding when an official clarification of the Constitution is required, there is a conflict among House Members, or a House interest needs resolution.
+E-Board may approve (by simple majority) a request (from a member) for a Judicial proceeding when an official clarification of the Constitution is required, there is a conflict among House Members, or a House interest needs resolution.
 \asection{Formation of a Judicial Board}
-A Judicial Board is made up of the Chair, the Evals director, and an additional voting member of the Executive Board chosen by a majority vote among the Executive Board.
-If either the Chair or Evals Director are deemed biased or unfit for a position on the Judicial Board, they will be replaced by another voting member of the Executive Board by means of a simple majority vote amongst the remaining Executive Board members.
+A Judicial Board is made up of the Chair, the Evals director, and an additional voting member of E-Board chosen by a majority vote among E-Board.
+If either the Chair or Evals Director are deemed biased or unfit for a position on the Judicial Board, they will be replaced by another voting member of E-Board by means of a simple majority vote amongst the remaining E-Board members.
 \asection{Judicial Investigation}
 The Judicial Board will be responsible for making all necessary inquiries into the matter of the request brought to the Judicial Board.
 \asection{Judicial Ruling}
 The Judicial Board may present an official ruling following the Judicial Investigation.
-This ruling may be appealed in the same manner as an Executive Board decision \ref{Appeals}.
+This ruling may be appealed in the same manner as an E-Board decision \ref{Appeals}.
 
 % ARTICLE VIII - ADHERENCE TO UNIVERSITY POLICIES
 \article{ADHERENCE TO UNIVERSITY POLICIES}

--- a/constitution.tex
+++ b/constitution.tex
@@ -75,7 +75,7 @@
 \article{Introduction}
 
 \asection{Name}
-The name of this Special Interest House shall be Computer Science House.
+The name of this Special Interest House is Computer Science House.
 
 \asection{Derivation of Authority}
 The Computer Science House shall recognize that it receives its right to function as a Special Interest House from the Center for Residence Life.

--- a/constitution.tex
+++ b/constitution.tex
@@ -78,7 +78,7 @@
 The name of this Special Interest House is Computer Science House.
 
 \asection{Derivation of Authority}
-The Computer Science House shall recognize that it receives its right to function as a Special Interest House from the Center for Residence Life.
+The Computer Science House shall recognize that it receives its right to function as a Special Interest House from the Center for Student Development.
 
 \asection{House Objectives}
 The objectives of Computer Science House are:

--- a/constitution.tex
+++ b/constitution.tex
@@ -19,6 +19,7 @@
 % Title page information
 \title{Computer Science House Constitution}
 \author{Computer Science House Constitution Committee}
+
 % Last Modified Date
 \newcommand{\datechanged}{Last Updated: \RevisionInfo}
 \date{\datechanged}
@@ -189,35 +190,46 @@ When describing the different memberships available, the following terms are use
 \end{description}
 
 \asection{Introductory Membership}
+
 \asubsection{Introductory Membership Qualifications}
 Intro Membership is open to all RIT students.
+
 \asubsection{Introductory Membership Selection}
 Applicants notify the House of their interest in membership by submitting an application to the Evals Director.
 They must then undergo the selection process as defined in \ref{Selection Processes}.
+
 \asubsection{Introductory Membership Expectations}
 Intro members are expected to meet all the requirements of the Intro Process, as described in \ref{Expectations of an Introductory Member}.
+
 \asubsection{Introductory Membership Privileges}
 Intro members receive the right to use Computer Science House facilities, to attend House functions, and to have housing priority over all persons who are not Computer Science House members.
+
 \asubsection{Introductory Membership Evaluations}
 Intro members are evaluated on their performance during the intro period.
 The intro evals process is described in \ref{Introductory Evaluation}.
+
 \asubsection{Introductory Membership Leave of Absence}
 After completion of the Intro Packet, an Intro member may request a leave of absence through the process described in \ref{Leave of Absence}.
+
 \asubsection{Introductory Membership Resignations}
 Intro members may resign by submitting the request for termination of membership to the Chair, or Evals Director in writing before the completion of the intro process.
 \asubsection{Introductory Membership Term}
 Intro membership shall last until the end of the intro process, at which time active membership is granted or membership is revoked.
 
 \asection{Active Membership}
+
 \asubsection{Active Membership Qualifications}
 Active Membership is open to all current RIT students who have passed the Intro Evals and their most recent Membership Evals.
+
 \asubsection{Active Membership Selection}
 Qualifying members may self-select into Active Membership by paying dues to the Financial Director and notifying the Evals Director.
 \\*\\*
 Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evals Director of their intent to participate, who will bring them up for a Simple Majority vote at the next House meeting.
 If the vote passes the Alumni is reinstated as an Active Member with Off-Floor status effective immediately.
+
 \asubsection{Active Membership Expectations}
 Active members are expected to be active participants in the House as defined in \ref{Expectations of House Members}.
+
 \asubsection{Active Membership Privileges}
 Active Members receive the right to:
 \begin{itemize}
@@ -231,8 +243,10 @@ Active Members receive the right to:
 \end{itemize}
 Active Members currently on co-op forfeit their right to vote on house issues, and likewise do not count towards quorum.
 Exceptions may be made at the discretion of the Evals Director.
+
 \asubsection{Active Membership Evaluations}
 Active Members are evaluated annually through the Evals Process as described in \ref{Evaluations Processes}.
+
 \asubsection{Active Membership Leave of Absence}
 An Active member may at any time request a leave of absence using the process described in \ref{Leave of Absence}.
 For the duration of an absence, a member:
@@ -241,70 +255,93 @@ For the duration of an absence, a member:
 	\item Does not count towards quorum
 	\item Will not be required to attend House Meeting
 \end{itemize}
+
 \asubsection{Active Membership Resignations}
 An Active member may resign by submitting, in writing, the reason for resignation to the Chair, or Evals Director.
 Instead of forfeiting membership, Active members who resign may elect to become Alumni defined in \ref{Alumni Membership Selection}.
 The resignation will take effect immediately and an announcement will be made at the following House Meeting.
+
 \asubsection{Active Membership Term}
 Active Membership shall last until the member: resigns or changes membership status.
 
 \asection{Alumni Membership}
+
 \asubsection{Alumni Membership Qualifications}
 Alumni Membership is open to all former Active members of Computer Science House who passed at least one Membership Evals and departed for reasons other than revocation of House Membership.
+
 \asubsection{Alumni Membership Selection}
 Active members who depart house (i.e. resign) after passing the current operating session's Membership Evals are considered to be Alumni in good standing.
 \\*\\*
 Active members who depart house without passing the current operating session's Membership Evals are considered to be Alumni in bad standing.
 This may be appealed to E-Board in order to pursue a different outcome.
+
 \asubsection{Alumni Membership Expectations}
 There are no expectations associated with the Alumni Membership status.
+
 \asubsection{Alumni Membership Privileges}
 Alumni Members shall receive the right to:
 \begin{itemize}
 	\item Use Computer Science House facilities
 	\item Attend Computer Science House functions
 \end{itemize}
+
 \asubsection{Alumni Membership Evaluations}
 Alumni Members are not subject to any evaluation.
+
 \asubsection{Alumni Membership Resignations}
 There are no resignations associated with Alumni Membership status.
+
 \asubsection{Alumni Membership Term}
 Alumni Membership shall last indefinitely or until the member chooses to pursue Active Membership.
 
 \asection{Honorary Membership}
+
 \asubsection{Honorary Membership Qualifications}
 Honorary Membership is open to a person whom the House feels has contributed great personal effort to the House and is deserving of House recognition.
+
 \asubsection{Honorary Membership Selection}
 Any House member may nominate a candidate for Honorary Membership by submitting the name in writing to the Evals Director.
 The Evals Director then begins the Honorary Membership Selection Process as defined in \ref{Selection Process for Honorary Members}
+
 \asubsection{Honorary Membership Expectations}
 Honorary Members are encouraged to remain in contact with the House.
+
 \asubsection{Honorary Membership Privileges}
 Honorary Members may advise in all issues brought before the House, use Computer Science House facilities, and attend Computer Science House functions.
+
 \asubsection{Honorary Membership Evaluations}
 Honorary Members are not subject to formal evaluations.
+
 \asubsection{Honorary Membership Resignations}
 An Honorary Member may resign by submitting in writing the reason for resignation to the Chair.
 The resignation will be read at the following House Meeting and become effective at that time.
+
 \asubsection{Honorary Membership Term}
 Honorary Membership shall last until the member resigns.
 
 \asection{Advisory Membership}
+
 \asubsection{Advisory Membership Qualifications}
 Advisory Membership is open to all members of the Rochester Institute of Technology professional, academic, or administrative staff.
+
 \asubsection{Advisory Membership Selection}
 E-Board may open nominations for Advisory Members.
 The candidates then participate in the Advisory Selection Process as defined in \ref{Selection Process for Advisory Members}
+
 \asubsection{Advisory Membership Expectations}
 Advisors are encouraged to offer advice and assistance to the House in any capacity the Advisor is able to help.
 Advisors are also encouraged to meet the House members and occasionally attend House activities.
+
 \asubsection{Advisory Membership Privileges}
 Advisory Members may advise in all issues brought before the House, use Computer Science House facilities, and attend Computer Science House functions.
+
 \asubsection{Advisory Membership Evaluations}
 Advisors are not subject to formal evaluations.
+
 \asubsection{Advisory Membership Resignations}
 An Advisor may resign by submitting in writing the reason for resignation to the Chair.
 The resignation will be read at the following House Meeting and become effective at that time.
+
 \asubsection{Advisory Membership Term}
 Advisory Membership shall last until the member resigns.
 
@@ -314,20 +351,26 @@ Computer Science House recognizes the need for its members to take care of their
 House will also help to reacclimate any returning member back to the culture of House upon their return.
 Upon approval of a leave of absence request, the Evals Director is notified and the member's leave is applied immediately.
 A member is also allowed to be physically present and also be on a leave of absence.
+
 \asubsection{Leave of Absence Request}
 A leave of absence request must include the following information about the member: name, email, phone number, start date, expected return date, and a reason for the leave.
 The request is then given to a ResLife staff member, excluding student employees, for approval.
 A leave of absence start date can be backdated.
 At no point does E-Board need to be informed of any details relating to the reason for the leave.
+
 \asubsection{Leave of Absence Duration}
 A leave of absence can be granted for up to the length of one semester.
+
 \asubsection{Leave of Absence Extension}
 A leave of absence can be extended by submitting a new request.
+
 \asubsection{Leave of Absence Return}
 A member may return from a leave of absence whenever they choose to.
 When a member wishes to return, they must in writing notify a ResLife staff member, excluding student employees, to end their leave of absence.
+
 \asubsection{Modified Evaluations}
 A member may request their evaluation period to be extended by the duration of the leave or to end of the Standard Operating Session, whichever comes first.
+
 \asubsection{Leave of Absence for an E-Board Member}
 The duties and responsibilities of an E-Board Member on leave are assumed using the process defined in Section \ref{Appointment of an Interim Director} until the member returns from their leave.
 Upon returning, the member may assume their position and the interim director is removed.
@@ -344,7 +387,9 @@ Ad Hoc directorships are created on an as-needed basis.
 They are generally very task oriented and are chaired by a House member.
 A directorship has some jurisdiction in its area of interest and often is responsible for the day-to-day decisions regarding its area of interest.
 Any large expenditures or large effect decisions must be brought before the entire House
+
 \asection{Members of E-Board}
+
 \asubsection{Voting Members}
 \begin{itemize}
 	\item Evals Director
@@ -356,19 +401,23 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item History Director
 	\item PR Director
 \end{itemize}
+
 \asubsection{Non-Voting Members}
 \begin{itemize}
 	\item Chair
 	\item House Secretary
 	\item Ad Hoc Director(s)
 \end{itemize}
+
 \asection{Closed E-Board}
 Closed E-Board Meetings are open only to the Chair, Voting Members of E-Board, and those with the express permission of E-Board.
 A closed E-Board meeting may be called at any time by any member of E-Board.
 However, the Chair and at least two-thirds of the Voting Members of E-Board must be present for the meeting to be called.
 
 \asection{Responsibilities}
+
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
+
 \asubsection{Responsibilities of E-Board}
 \begin{enumerate}
 	\item To hold a weekly meeting specific to their responsibilities and submit notes to the House
@@ -420,7 +469,6 @@ However, the Chair and at least two-thirds of the Voting Members of E-Board must
 	\item To oversee the organization, initiation, and execution of House philanthropic events
 	\item To preserve and improve the public image of House
 	\item To collaborate with other E-Board members to organize, initiate, execute, and advertise any events that are intended to be attended by persons whom have never been Active Members
-
 \end{enumerate}
 
 \asubsection{Responsibilities of the Financial Director}
@@ -484,15 +532,19 @@ However, the Chair and at least two-thirds of the Voting Members of E-Board must
 \end{enumerate}
 
 \asection{Operations}
+
 \asubsection{Operations of the Financial Directorship}
+
 \asubsubsection{Amount of House Dues}
 The amount of dues for Active Members will be eighty dollars (\$80.00) per Academic Semester.
+
 \asubsubsection{Collection of House Dues}
 The collection period of house dues will be decided in conjunction with the ResLife and Housing departments.
 During the dues collection period, dues for on-floor members (for both semesters) are collected through the member’s RIT bill.
 Dues for off-floor members are to be collected during this period as well by the Financial Director.
 For any member who moves on or off-floor during the year, any difference between dues paid and dues owed should be collected.
 Dues for any alumnus/alumnae in good standing are to be collected when intention to pay is expressed to the Financial Director.
+
 \asubsubsubsection{Rules for Giving Exceptions and Exemptions for House Dues}
 If a member is unable to pay dues upon request, they may appeal their situation to the Financial Director.
 If the Financial Director deems their situation appropriate, they may grant specific extensions or reductions of the member's payment as they see fit.
@@ -503,6 +555,7 @@ In the case the Financial Director or E-Board decides the situation is appropria
 Additional time and reduction of dues may both be given to a member in an appropriate situation.
 All dues must be collected in full before the annual membership evals (\ref{Membership Evaluation}).
 After this date, dues collection is suspended until the start of the next academic year.
+
 \asubsubsection{Breakdown of Dues for Directorship Budgets}
 \begin{center}
 \begin{tabular}[c]{|l c|}
@@ -554,8 +607,10 @@ Funds allocated for a project not spent by the end of the Standard Operating Ses
 
 % BY-LAW IV - OPERATIONS OF THE EVALUATIONS DIRECTORSHIP
 \asubsection{Operations of the Evaluations Directorship}
+
 \asubsubsection{The Introductory Process}
 The Intro Process is designed to provide an easy means for Intro Members to meet existing House members, learn history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
+
 \asubsubsubsection{The Evaluation Period}
 The Process will occur either once or twice per semester, and will last for six (6) weeks.
 The Process shall be initiated by the Evals Director during either the first and second week of each semester.
@@ -563,6 +618,7 @@ E-Board may hold a closed ballot Simple Majority vote to extend the Intro Proces
 If an Intro Process is extended, the Introductory Evaluation shall occur at the termination of the extended Process, which may be outside of the period defined in \ref{Introductory Evaluation}.
 If deemed necessary by the Evals Director, or by an E-Board simple majority vote, the second intro process must begin within nine (9) days of the first process ending.
 If a second Intro Process is approved, the Evals Director may initiate a new Intro Packet within the first or second week of the Intro Process.
+
 \asubsubsubsection{The Introductory Packet}
 Each Intro Process participant, after the first week, is given two (2) weeks to return a document that should contain a signature from all Active Members who have passed a Membership Evals, all Active Resident Members, all Resident Intro Members, and ten (10) of any combination of the following:
 \begin{itemize}
@@ -571,6 +627,7 @@ Each Intro Process participant, after the first week, is given two (2) weeks to 
 	\item Advisory members
 \end{itemize}
 At the discretion of the Evals Director, any Intro Packet may be extended to accommodate extenuating circumstances.
+
 \asubsubsubsection{Expectations of an Introductory Member}
 Before the end of the Process, an Intro Member is expected to:
 \begin{itemize}
@@ -588,12 +645,15 @@ The Introductory Evaluation is the process by which House chooses which Intro Me
 It occurs at the conclusion of the final week of the Process.
 
 \asubsubsubsubsection{Voting}
+
 On a member by member basis, this evaluation process determines if each Intro member has successfully completed the Intro Process requirements \ref{Expectations of an Introductory Member}.
 A Simple Majority vote with a quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.
 In order for an Active Member to be counted as a Possible Vote they must meet the requirements outlined in \ref{Expectations of Voting Members}.
 Neither absentee nor proxy votes are allowed.
 House may choose any of the Outcomes for each member.
+
 \asubsubsubsubsection{Expectations of Voting Members}
+
 The following requirements must be met by the beginning of the Introductory Evals for an Active Member to be allowed to vote. 
 Any of these requirements may be waived by the Evals Director or a simple majority vote by E-Board
 \begin{itemize}
@@ -615,8 +675,10 @@ Any of these requirements may be waived by the Evals Director or a simple majori
 		When the deadline expires, the conditional will be brought before E-Board who will assess its completeness.
 		A conditional member who does not meet these additional requirements forfeits membership.
 \end{enumerate}
+
 \asubsubsection{Selection Processes}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
+
 \asubsubsubsection{Selection Process for Students Attending RIT for at Least One Semester}
 \begin{enumerate}
 	\item The applicant submits an application to the Evals Director for review.
@@ -630,6 +692,7 @@ The member does, however, have the right to use Computer Science House's facilit
 The member is not required to pay dues during the Intro Process.
 \\* \\*
 Additional Note: No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
+
 \asubsubsubsection{Selection Process for First Semester and Entering RIT Students}
 \begin{enumerate}
 	\item During Spring semester, the Evals Director selects a group of Active Members to form a Selections Committee.
@@ -644,6 +707,7 @@ The member does, however, have the right to use Computer Science House's facilit
 The member is not required to pay dues during the Intro Process.
 \\* \\*
 Additional Note: No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
+
 \asubsubsubsection{Selection Process for Honorary Members}
 \begin{enumerate}
 	\item A House Member submits to the Evals Director a nomination for a person they feel is deserving of Honorary Membership.
@@ -654,6 +718,7 @@ Additional Note: No hazing shall occur at any time during the Selection Process 
 		Ballots are distributed and voting must remain open for a minimum of forty-eight hour period.
 	\item The candidate is notified of their selection as an Honorary Member and presented with the honor.
 \end{enumerate}
+
 \asubsubsubsection{Selection Process for Advisory Members}
 \begin{enumerate}
 	\item When there is a perceived need, E-Board may open nominations for Advisory Members.
@@ -673,9 +738,11 @@ All E-Board members are expected to attend the Semi-Annual Evals Meetings to ass
 \\* \\*
 At the beginning of any Evals Process listed herein, the Evals Director must read the sections of the Computer Science House Constitution used during the respective Evals Process.
 It is incumbent upon each House member to provide the Evals Director with whatever information they feel is necessary to ensure an accurate evaluation.
+
 \asubsubsubsection{Membership Evaluation}
 The Membership Evaluation process occurs once per academic year.
 It is performed as part of the Evals Process that takes place during the spring semester to comply with RIT Housing deadlines.
+
 \asubsubsubsubsection{Voting}
 Any Active Member who has completed all of the requirements as defined in \ref{Expectations of House Members} at the beginning of the Membership Evals passes their Membership Evals without being voted on or evaluated by the quorum.
 All Active Members who have not recieved an exemption from E-Board prior to the Membership Evals will be evaluated on a Member by Member basis by a quorum of Active Members.
@@ -699,6 +766,7 @@ If the conditional is approved by the Evals Director, it is then voted on by Hou
 Each conditional consists of a set of additional requirements a deadline for completing them.
 When the deadline expires, the conditional will be brought before E-Board who will assess its completeness.
 A conditional member who does not meet these additional requirements will have failed the evaluation.
+
 \asubsubsubsection{Appeals Process}
 If a member disagrees with the outcome of any evaluation, (e.g. is not asked to return to the House for the following year) and wishes to appeal the decision, they may do so as stated in \ref{Appeals}.
 \\* \\*
@@ -717,10 +785,12 @@ This participation will be evaluated by E-Board.
 All Active and Intro Members have a housing status.
 This status indicates their right to priority housing on the floor.
 Any Alumni Member in good standing will maintain their previous On Floor status upon a return to Active membership.
+
 \asubsubsubsection{On-Floor Status}
 Members with On-Floor status are eligible to live on the floor.
 To be granted On-Floor status, members may notify the Evals Director that they would like to come up for a vote.
 The Evals Director will then bring them up for vote at the next meeting.
+
 \asubsubsubsection{Off-Floor Status}
 Members with Off-Floor status do not have the right to live on the floor.
 They still have access to all other privileges associated with their membership, and may still accumulate Housing Priority Points.
@@ -731,6 +801,7 @@ The member with top priority is the member with on-floor status and the most Hou
 Housing Priority Points are accumulated once per Operating Session at the conclusion of the Membership Evals. Each Active Member who passes the Membership Evals is granted two (2) Housing Priority Points.
 \\* \\*
 In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
+
 \asubsubsubsection{Single Room Assignments}
 When a single room on the House becomes available it is offered to the member who carries the highest Housing Priority as defined in \ref{Housing Priority System}.
 In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
@@ -738,6 +809,7 @@ If that House member declines the option, it will be offered to the member with 
 This process continues until a member selects to move into the single room.
 Once in a single room, a House member retains the assignment until voluntarily giving it up.
 It should be noted that members selecting this option must agree to any additional charges applied by ResLife for residing in a single room.
+
 \asubsubsubsection{Double Rooms as Single rooms}
 During the third week of each semester, if there is no waiting list for residency on the House, any vacant rooms will be offered to House members as single rooms assignments according to the method as described in \ref{Single Room Assignments}.
 It should be noted that this does not mean members will be relocated into empty spaces so that the member with top priority is offered the single.
@@ -785,6 +857,7 @@ The Code of Conduct located at \url{https://github.com/ComputerScienceHouse/Code
 \\* \\*
 Members are bound to the Code of Conduct revision that they sign when initially creating their account.
 Members may sign a more recent revision of the Code of Conduct to update their agreement.
+
 \asubsubsubsection{Changes}
 The following process is used for making changes to the Code of Conduct document.
 \begin{enumerate}
@@ -793,8 +866,8 @@ The following process is used for making changes to the Code of Conduct document
 	\item The final proposal is presented at the next House Meeting and ballots are distributed for a Balloted House vote as described in \ref{Balloted Vote}.
 \end{enumerate}
 
-
 \asection{Qualifications}
+
 \asubsection{Qualifications to be the Chair, Evals Director}
 \begin{enumerate}
 	\item Candidates must be Active Members during the term of office
@@ -802,12 +875,14 @@ The following process is used for making changes to the Code of Conduct document
 	\item Candidates must have at least one full semester of House membership as an Active Member
 	\item Elected or selected candidates may not hold a simultaneous voting E-Board position, and must therefore resign their current position, or the position of Chair, should they be elected
 \end{enumerate}
+
 \subsubsection{Qualifications to be the Social Director(s), Financial Director, R\&D Director(s), IMPs Director, History Director, PR Director}
 \begin{enumerate}
 	\item Candidates must be Active Members during the term of office
 	\item Candidates must have at least one full semester of House membership as an Active Member
 	\item Elected or selected candidates may not hold two simultaneous voting E-Board positions, and must therefore resign their current position or decline a second position should they be elected or selected to a second voting position
 \end{enumerate}
+
 \asubsection{Qualifications to be the OpComm Director}
 \begin{enumerate}
 	\item Candidates must be a current RTP \ref{Operations of the OpComm Directorship}.
@@ -835,6 +910,7 @@ The following process is used for making changes to the Code of Conduct document
 \end{enumerate}
 
 \asection{Selection}
+
 \asubsection{Dual Directorship}
 Social and R\&D are the only voting E-Board positions that allow for Dual Directorship.
 If two candidates elect to run as a Dual Directorship, their names are placed together on a single line of the election ballot.
@@ -851,6 +927,7 @@ The following special cases cover the operation of a dual directorship:
 	\item A member of a dual directorship may not hold any other E-Board position.
 	\item When attendance requirements call for the dual directorship position to be present, both dual directorship members are to fulfill the requirements.
 \end{itemize}
+
 \subsubsection{Selection of the Chair, Evals Director, Social Director(s), Financial Director, IMPs Director, History Director,  R\&D Director(s), PR Director}
 \begin{enumerate}
 	\item The opening of the E-Board position(s) is announced at a House meeting and nominations for the position are taken for a minimum of a seventy-two hour period.
@@ -873,6 +950,7 @@ The following special cases cover the operation of a dual directorship:
 		If not, the winner will assume office at the end of the current term (\ref{Term}).
 		Any office whose winner declines the election, or whose winner does not fulfill the requirements of the elected office, shall have their votes redistributed in the same process as a loser in \ref{Alternative Vote}.
 \end{enumerate}
+
 \asubsection{Selection of the OpComm Director}
 \begin{enumerate}
 	\item A candidate for the OpComm Directorship shall be chosen by the current RTPs.
@@ -882,11 +960,13 @@ The following special cases cover the operation of a dual directorship:
 	\item All current Voting E-Board Members must be present during the discussion and voting period unless that member is a candidate for the position, in which case the member is absent and their vote is abstained.
 		A simple majority E-Board vote, as described in \ref{Simple Majority}, is taken to determine whether the candidate is selected for the position.
 \end{enumerate}
+
 \asubsection{Selection of Ad Hoc Directors}
 \begin{enumerate}
 	\item When E-Board or a group of House members feels an Ad Hoc Directorship is necessary, they present their plans to E-Board and E-Board decides by simple majority vote whether directorship status is granted.
 	\item When the Ad Hoc Directorship is granted status, a director is appointed, and duties, budgetary, and membership considerations are defined.
 \end{enumerate}
+
 \asubsection{Selection of the House Secretary}
 E-Board may choose to select a current voting E-Board member, or to select any interested Active member, as House Secretary.
 The selection process can be an informal appointment, or follow an election process similar to other voting E-Board positions.
@@ -941,31 +1021,39 @@ If the vote passes, E-Board may discuss and make a new ruling by another Simple 
 % ARTICLE VI - VOTING
 \article{Voting}
 This section outlines the different types of votes and ballots used to make House decisions and defines relevant terminology.
+
 \asection{Definitions}
 \asubsection{Total Number of Possible Votes}
 The sum of the number of Active members eligible to vote on the issue.
+
 \asubsection{Total Number of Votes Cast}
 The Total Number of Votes Cast is defined as the total number of votes received for every voting option minus the number of abstentions.
+
 \asubsection{Quorum}
 A Quorum is defined by the minimum number of votes cast required for a vote to be official.
 It is a fraction or a percentage of the total number of possible votes.
 Any member present for an Immediate Vote or given a ballot who does not explicitly cast their vote is counted as an Abstention.
 A Quorum is reached if the Total Number of Votes Cast plus the number of Abstentions is equal to or exceeding the minimum number of votes required.
+
 \asubsection{Proxy Ballot}
 A Proxy Vote is defined as any ballot that was cast by one member on behalf of another member.
 Any member may cast a Proxy Vote for another member who is unable to actually participate in the vote.
 A Proxy Vote must be explicitly written down and signed by the member not in attendance.
 The count of all Proxy Vote must be recorded and announced in all votes.
 Proxy Votes are only permissible where explicitly stated, at the discretion of the Chair of the Vote.
+
 \asubsection{Abstention}
 An Abstention is defined as a vote indicating a neutral position in the vote.
 A means to abstain must always be provided in a vote.
 Abstentions are counted towards a Quorum, but not towards the Total Number of Votes Cast used to determine if a vote passes or not.
+
 \asubsection{Vote Counters}
 The Chair of the Vote is a vote counter and will additionally select two other members to count votes.
 
 \asection{Types of Voting}
+
 \asubsection{Alternative Vote}
+
 \asubsubsection{Method of Vote}
 Votes are cast on paper ballots, which provide a means to indicate every possible option in the vote.
 A ballot is then distributed to each House member eligible to cast a vote and collected in the designated ballot box for a pre-specified length of time.
@@ -978,29 +1066,39 @@ Voters rank the options by placing a '1' by their first choice, a '2' by their s
 For constitutional modification, candidate selection, and officer removal votes, the voting period must be at least forty-eight (48) hours in length.
 For any other type of vote, the voting period must be at least twenty-four (24) hours.
 The minimum length of the voting period may be explicitly lengthened, but never shortened, in the text describing the actual vote.
+
 \asubsection{Balloted Vote}
+
 \asubsubsection{Method of Vote}
 Votes are cast on paper ballots, which provide a means to indicate every possible option in the vote.
 A ballot is then distributed to each House member eligible to cast a vote and collected in the designated ballot box for a pre-specified length of time.
 At the end of the voting period, the Chair of the Vote collects the ballots, closing the voting period.
 The Vote Counters then tally the results.
+
 \asubsubsection{Voting Period}
 For constitutional modification, candidate selection, and officer removal votes, the voting period must be at least forty-eight (48) hours in length.
 For any other type of vote, the voting period must be at least twenty-four (24) hours.
 The minimum length of the voting period may be explicitly lengthened, but never shortened, in the text describing the actual vote.
+
 \asubsection{Immediate Vote}
+
 \asubsubsection{Method of Vote}
 The Chair of the Vote will state all possible ways to vote, then call out each possibility one at a time.
 The chairing member will count the number of members casting their immediate vote for that possibility.
+
 \asubsubsection{Voting Period}
 An immediate vote lasts as long as it takes for all votes to be tallied.
+
 \asubsection{Secret Immediate Vote}
+
 \asubsubsection{Method of Vote}
 The Chair of the Vote will state all possible ways to vote, then call out each possibility one at a time.
 Votes are kept anonymous.
 The chairing member and Vote Counters will count the number of members casting their immediate vote for that possibility.
+
 \asubsubsection{Voting Period}
 A secret immediate vote lasts as long as it takes for all votes to be tallied.
+
 \asubsection{Batch Vote}
 When a Batch Vote is called for by the Chair of the Vote, a subset of the voting docket may be amended to a single vote.
 A Two-Thirds Immediate Vote is required to allow a Batch Vote to take place.
@@ -1010,26 +1108,33 @@ If the call for Batch Vote passes, the subset may then be voted on, otherwise th
 The Number of Votes Required refers to the numbers required to achieve a quorum and for a vote to pass.
 Below are listed four standard votes.
 Numbers for non-standard votes are defined in the section describing the actual vote.
+
 \asubsection{Simple Majority}
 In a Simple Majority Vote, a Quorum is reached if the Total Number of Votes Cast is equal to or exceeds one-half the Total Number of Possible Votes.
 An option in the vote passes if the number of votes cast for that option is larger than the number of votes cast for every other option individually.
+
 \asubsection{Fifty Percent}
 In a Fifty Percent Vote, a Quorum is reached if the Total Number of Votes Cast is equal to or exceeds one-half the Total Number of Possible Votes.
 An option in the vote passes if the number of votes cast for that option exceeds fifty percent of the Total Number of Votes Cast.
+
 \asubsection{Two-Thirds}
 In a Two-thirds Vote, a Quorum is reached if the Total Number of Votes Cast is equal to or exceeds two-thirds the Total Number of Possible Votes.
 An option in the vote passes if the number of votes cast for the option equals or exceeds two-thirds of the Total Number of Votes Cast.
+
 \asubsection{Three-Quarters}
 In a Three-Quarters Vote, a Quorum is reached if the Total Number of Votes Cast is equal to or exceeds three-quarters the Total Number of Possible Votes.
 An option in the vote passes if the number of votes cast for the option equals or exceeds three-quarters of the Total Number of Votes Cast.
+
 \asubsection{Alternative}
 The winning option is selected outright if it gains more than half the votes cast as a first preference.
 If not, the option with the fewest number of first preference votes is eliminated and their votes move to the second preference marked on the ballot papers.
 This process continues until one option has half of the votes cast and is elected.
 
 \asection{Ties Between Vote Options}
+
 \asubsection{With Pass/Fail}
 If the number of votes cast for the pass option equals the number of votes cast for the fail option, then the vote has failed.
+
 \asubsection{With Multiple Options}
 If multiple options may pass, a tie does not present a problem.
 If only one option may pass, then the vote must be recast or tabled at the discretion of the Chair of the Vote.
@@ -1038,29 +1143,37 @@ In the event of a tie in an E-Board vote, the Chair may cast the tie-breaking vo
 % ARTICLE VII - JUDICIAL
 \article{Judicial}
 E-Board may approve (by simple majority) a request (from a member) for a Judicial proceeding when an official clarification of the Constitution is required, there is a conflict among House Members, or a House interest needs resolution.
+
 \asection{Formation of a Judicial Board}
 A Judicial Board is made up of the Chair, the Evals director, and an additional voting member of E-Board chosen by a majority vote among E-Board.
 If either the Chair or Evals Director are deemed biased or unfit for a position on the Judicial Board, they will be replaced by another voting member of E-Board by means of a simple majority vote amongst the remaining E-Board members.
+
 \asection{Judicial Investigation}
 The Judicial Board will be responsible for making all necessary inquiries into the matter of the request brought to the Judicial Board.
+
 \asection{Judicial Ruling}
 The Judicial Board may present an official ruling following the Judicial Investigation.
 This ruling may be appealed in the same manner as an E-Board decision \ref{Appeals}.
 
 % ARTICLE VIII - ADHERENCE TO UNIVERSITY POLICIES
 \article{ADHERENCE TO UNIVERSITY POLICIES}
+
 \asection{Anti-Hazing}
+
 \asubsection{RIT Hazing Policy (RIT Student Conduct Process; IV. RIT Code of Conduct; 14. Hazing/Failure to Report
 Hazing)}
 Hazing/Failure to Report Hazing.
 Behavior, regardless of intent, which endangers the emotional, or physical health and safety of a Student for the purpose of membership, affiliation with, or maintaining membership in, a group or Student Organization. Hazing includes any level of participation, such as being in the presence, having awareness of hazing, or failing to report hazing.
 Examples of hazing include, but are not limited to, beating or branding, sleep deprivation or causing excessive fatigue, threats of harm, forcing or coercing consumption of food, water, alcohol or other drugs, or other substances, verbal abuse, embarrassing, humiliating, or degrading acts, or activities that induce, cause or require the Student to perform a duty or task which is not consistent with fraternal law, ritual or policy or involves a violation of local, state or federal laws, or the RIT Code of Conduct.
+
 \asubsection{NY State Hazing Law}
+
 \asubsubsection{§ 120.16 Hazing in the first degree.}
 A person is guilty of hazing in the first degree when, in the course of
 another person's initiation into or affiliation with any organization, he intentionally or recklessly engages in
 conduct which creates a substantial risk of physical injury to such other person or a third person and thereby
 causes such injury. Hazing in the first degree is a class A misdemeanor.
+
 \asubsubsection{§ 120.17 Hazing in the second degree.}
 A person is guilty of hazing in the second degree when, in the course of another person's initiation or affiliation with any organization, he intentionally or recklessly engages in conduct which creates a substantial risk of physical injury to such other person or a third person.
 Hazing in the second degree is a violation.

--- a/constitution.tex
+++ b/constitution.tex
@@ -161,7 +161,7 @@ E-Board may choose to approve or reject the nomination by Simple Majority vote.
 % ARTICLE III - GENERAL OPERATIONS OF THE HOUSE
 \article{General Operations of the House}
 \asection{Standard Operating Session}
-The Standard Operating Session for Computer Science House is during the twenty-eight weeks of Fall and Spring semesters.
+The Standard Operating Session for Computer Science House is during the Fall and Spring semesters.
 The Summer Sessions, Intersessions, Institute breaks, and all end of Semester Exam Weeks are considered non-standard operating sessions.
 Unless explicitly stated otherwise, the requirements and expectations defined in the constitution are for the Standard Operating Session.
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -87,6 +87,22 @@ The objectives of Computer Science House are:
 	\item To provide a friendly and comfortable living environment in the residence halls
 \end{enumerate}
 
+\article{Abbreviations and Definitions}
+
+\begin{itemize}
+	\item Evaluations Director - Evals Director
+	\item Research and Development Director(s) - R\&D Director(s)
+	\item House Improvements Director - Imps Director
+	\item Operational Communications Director - OpComm Director
+	\item House History Director - History Director
+	\item Public Relations Director - PR Director
+	\item Root Type Persons - RTPs
+	\item Introductory Member - Intro Member
+	\item Introductory Process - Intro Process
+	\item Introductory Evaluations - Intro Evals
+	\item Executive Board - E-Board
+\end{itemize}
+
 % ARTICLE II - CONSTITUTIONAL STRUCTURE
 \article{Constitutional Structure}
 

--- a/constitution.tex
+++ b/constitution.tex
@@ -113,9 +113,6 @@ Many of the commonly used abbreviations will be listed here, and the abbreviatio
 % ARTICLE II - CONSTITUTIONAL STRUCTURE
 \article{Constitutional Structure}
 
-\asection{House Charter}
-The House Charter is a document drafted by ResLife, setting down the guidelines within which this House operates and from which it derives its authority.
-
 \asection{Constitution}
 The House Constitution is written and maintained by the House and defines the major aspects, goals, and governing structure of the house.
 It is reviewed annually by ResLife.

--- a/constitution.tex
+++ b/constitution.tex
@@ -47,8 +47,6 @@
 \newcommand{\asubsubsection}[1]{\paragraph{#1} \label{#1}}
 \renewcommand{\theparagraph}{\arabic{section}.\Alph{subsection}.\arabic{subsubsection}.\Alph{paragraph}}
 
-\newcommand{\ampersand}{&}
-
 % Adding \a(sub){3,4}section during merge of bylaws and articles -- I feel _really_ dirty
 \setcounter{secnumdepth}{7}
 \setcounter{tocdepth}{7}
@@ -107,7 +105,7 @@ Many of the commonly used abbreviations will be listed here, and the abbreviatio
 	\item Root Type Person - RTP
 	\item Introductory - Intro
 	\item Executive Board - E-Board
-	\item Residence Life - ResLife
+	\item Department of Residence Life - ResLife
 	\item Constitutional Maintainer - Maintainer
 \end{enumerate}
 
@@ -205,21 +203,21 @@ Intro members are expected to meet all the requirements of the Intro Process, as
 Intro members receive the right to use Computer Science House facilities, to attend House functions, and to have housing priority over all persons who are not Computer Science House members.
 
 \asubsection{Introductory Membership Evaluations}
-Intro members are evaluated on their performance during the intro period.
-The intro evals process is described in \ref{Introductory Evaluation}.
+Intro Members are evaluated on their performance during the intro period.
+The Intro Evals process is described in \ref{Introductory Evaluation}.
 
 \asubsection{Introductory Membership Leave of Absence}
 After completion of the Intro Packet, an Intro member may request a leave of absence through the process described in \ref{Leave of Absence}.
 
 \asubsection{Introductory Membership Resignations}
-Intro members may resign by submitting the request for termination of membership to the Chair, or Evals Director in writing before the completion of the intro process.
+Intro members may resign by submitting the request for termination of membership to the Chair or Evals Director in writing before the completion of the intro process.
 \asubsection{Introductory Membership Term}
-Intro membership shall last until the end of the intro process, at which time active membership is granted or membership is revoked.
+Intro membership shall last until the end of the Intro Process, at which time active membership is granted or membership is revoked.
 
 \asection{Active Membership}
 
 \asubsection{Active Membership Qualifications}
-Active Membership is open to all current RIT students who have passed the Intro Evals and their most recent Membership Evals.
+Active Membership is open to all students currently enrolled at RIT who have passed the Intro Evals and their most recent Membership Evals.
 
 \asubsection{Active Membership Selection}
 Qualifying members may self-select into Active Membership by paying dues to the Financial Director and notifying the Evals Director.
@@ -257,7 +255,7 @@ For the duration of an absence, a member:
 \end{itemize}
 
 \asubsection{Active Membership Resignations}
-An Active member may resign by submitting, in writing, the reason for resignation to the Chair, or Evals Director.
+An Active member may resign by submitting, in writing, the reason for resignation to the Chair or Evals Director.
 Instead of forfeiting membership, Active members who resign may elect to become Alumni defined in \ref{Alumni Membership Selection}.
 The resignation will take effect immediately and an announcement will be made at the following House Meeting.
 
@@ -539,7 +537,7 @@ However, the Chair and at least two-thirds of the Voting Members of E-Board must
 The amount of dues for Active Members will be eighty dollars (\$80.00) per Academic Semester.
 
 \asubsubsection{Collection of House Dues}
-The collection period of house dues will be decided in conjunction with the ResLife and Housing departments.
+The collection period of house dues will be decided in conjunction with ResLife and Housing.
 During the dues collection period, dues for on-floor members (for both semesters) are collected through the member’s RIT bill.
 Dues for off-floor members are to be collected during this period as well by the Financial Director.
 For any member who moves on or off-floor during the year, any difference between dues paid and dues owed should be collected.
@@ -553,7 +551,7 @@ If E-Board disagrees with the Financial Director, E-Board may reduce the require
 If E-Board agrees with the Financial director, the member’s payment is considered delinquent and the member’s privileges are revoked until payment can be made.
 In the case the Financial Director or E-Board decides the situation is appropriate, the member's dues may be partially or fully excused, or the member may be given additional time to pay their dues. 
 Additional time and reduction of dues may both be given to a member in an appropriate situation.
-All dues must be collected in full before the annual membership evals (\ref{Membership Evaluation}).
+All dues must be collected in full before the annual Membership Evals (\ref{Membership Evaluation}).
 After this date, dues collection is suspended until the start of the next academic year.
 
 \asubsubsection{Breakdown of Dues for Directorship Budgets}
@@ -646,7 +644,7 @@ It occurs at the conclusion of the final week of the Process.
 
 \asubsubsubsubsection{Voting}
 
-On a member by member basis, this evaluation process determines if each Intro member has successfully completed the Intro Process requirements \ref{Expectations of an Introductory Member}.
+On a member by member basis, this evaluation process determines if each Intro Member has successfully completed the Intro Process requirements \ref{Expectations of an Introductory Member}.
 A Simple Majority vote with a quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.
 In order for an Active Member to be counted as a Possible Vote they must meet the requirements outlined in \ref{Expectations of Voting Members}.
 Neither absentee nor proxy votes are allowed.
@@ -686,7 +684,7 @@ Any of these requirements may be waived by the Evals Director or a simple majori
 	\item The application materials are then reviewed at an Evals meeting.
 	Then a simple majority vote, of attending members, is held on whether or not to accept the person as an Intro Member.
 \end{enumerate}
-Note: Most membership privileges do not initiate until successful completion of the intro process.
+Note: Most membership privileges do not initiate until successful completion of the Intro Process.
 This means that until the member has passed the Introductory Evals, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
 The member does, however, have the right to use Computer Science House's facilities.
 The member is not required to pay dues during the Intro Process.
@@ -701,7 +699,7 @@ Additional Note: No hazing shall occur at any time during the Selection Process 
             A subset of Intro Members will be offered On-Floor status and will be able to select a room on floor. 
             The other Intro Members will have Off-Floor status, but will otherwise have the same privileges and responsibilities.
 \end{enumerate}
-Note: Most membership privileges do not initiate until successful completion of the intro process.
+Note: Most membership privileges do not initiate until successful completion of the Intro Process.
 This means that until the member has passed the Introductory Evals, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
 The member does, however, have the right to use Computer Science House's facilities.
 The member is not required to pay dues during the Intro Process.
@@ -1014,7 +1012,7 @@ The vote of a vacated E-Board position shall be cast as an abstention in all E-B
 
 \asection{Appeals}
 Decisions made by E-Board may be appealed and overturned.
-To initiate an appeal, a member must have the support of three voting E-Board members, or a petition with the signatures of one-third of Active Members.
+To initiate an appeal, a member must have the support of three voting E-Board Members, or a petition with the signatures of one-third of Active Members.
 After the appeal is presented, a Simple Majority vote is held by E-Board whether or not to overturn and reevaluate the decision.
 If the vote passes, E-Board may discuss and make a new ruling by another Simple Majority vote.
 


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Resolve #87 by removing mention of specific number of weeks in the standard operating session
