### PR TITLE
Resolve #89 - replace qualifying with alumni in good standing

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -186,7 +186,7 @@ Introductory membership shall last until the end of the introductory process, at
 \asubsection{Active Membership Qualifications}
 Active Membership is open to all students currently enrolled at the Rochester Institute of Technology who have passed the Introductory Evaluation and their most recent Membership Evaluation.
 \asubsection{Active Membership Selection}
-Qualifying members may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director.
+Alumni Members in good standing may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director.
 \\*\\*
 Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evaluations Director of their intent to participate, who will bring them up for a Simple Majority vote at the next House meeting.
 If the vote passes the Alumni is reinstated as an Active Member with Off-Floor status effective immediately.


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Resolve #89 
