### PR TITLE
Resolve #76 Restructured membership sections

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -158,124 +158,84 @@ When describing the different memberships available, the following terms are use
 \end{description}
 
 \asection{Introductory Membership}
-\asubsection{Introductory Membership Qualifications}
-Introductory Membership is open to all students at the Rochester Institute of Technology.
-\asubsection{Introductory Membership Selection}
-Applicants notify the House of their interest in membership by submitting an application to the Evaluations Director.
-They must then undergo the selection process as defined in \ref{Selection Processes}.
-\asubsection{Introductory Membership Expectations}
-Introductory members are expected to meet all the requirements of the Introductory Process, as described in \ref{Expectations of an Introductory Member}.
-\asubsection{Introductory Membership Privileges}
-Introductory members receive the right to use Computer Science House facilities, to attend House functions, and to have housing priority over all persons who are not Computer Science House members.
-\asubsection{Introductory Membership Evaluations}
-Introductory members are evaluated on their performance during the introductory period.
-The introductory evaluation process is described in \ref{Introductory Evaluation}.
-\asubsection{Introductory Membership Leave of Absence}
-After completion of the Introductory Packet, an Introductory member may request a leave of absence through the process described in \ref{Leave of Absence}.
-\asubsection{Introductory Membership Resignations}
-Introductory members may resign by submitting the request for termination of membership to the Chairperson, or Evaluations Director in writing before the completion of the introductory process.
-\asubsection{Introductory Membership Term}
-Introductory membership shall last until the end of the introductory process, at which time active membership is granted or membership is revoked.
+
+\begin{description}
+	\item[Qualifications:] Students currently enrolled at the Rochester Institute of Technology
+	\item[Selection:] Submit an application to the Evaluations Director
+	\item[Expectations:] Meet all requirements of the Introductory Process as described in \ref{Expectations of an Introductory Member}
+	\item[Privileges:] Use Computer Science House facilities, attend House functions, and have housing priority over anyone who is not a member
+	\item[Evaluations:] Introductory Members are evaluated at the end of the Introductory period according to the process defined in \ref{Introductory Evaluation}
+	\item[Leave of Absence:] An Introductory Member may request a leave of absence through the process described in \ref{Leave of Absence}
+	\item[Resignations:] Submit a request for termination of membership to the Chairperson or Evaluations Director before the completion of the Introductory Process
+	\item[Term:] Introductory Membership lasts until the end of the Introductory Process, at which time active membership is granted or membership is revoked
+\end{description}
 
 \asection{Active Membership}
-\asubsection{Active Membership Qualifications}
-Active Membership is open to all students currently enrolled at the Rochester Institute of Technology who have passed the Introductory Evaluation and their most recent Membership Evaluation.
-\asubsection{Active Membership Selection}
-Alumni Members in good standing may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director.
-\\*\\*
-Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evaluations Director of their intent to participate, who will bring them up for a Simple Majority vote at the next House meeting.
-If the vote passes the Alumni is reinstated as an Active Member with Off-Floor status effective immediately.
-\asubsection{Active Membership Expectations}
-Active members are expected to be active participants in the House as defined in \ref{Expectations of House Members}.
-\asubsection{Active Membership Privileges}
-Active Members receive the privilege to:
-\begin{itemize}
-	\item Vote on all issues brought before the House
-	\item Reside on the House
-	\item Hold an Executive Board office on the House
-	\item Use Computer Science House facilities
-	\item Attend Computer Science House functions
-	\item Receive priority for available housing on the House when returning from cooperative education
-	\item Guaranteed housing in compliance with the Residence Life policies regarding Special Interest Houses and the Housing Selection Process (if they have On-Floor status)
-\end{itemize}
-Active Members currently on co-op forfeit their right to vote on house issues, and likewise do not count towards quorum.
-Exceptions may be made at the discretion of the Evaluations Director.
-\asubsection{Active Membership Evaluations}
-Active Members are evaluated annually through the Evaluation Process as described in \ref{Evaluations Processes}.
-\asubsection{Active Membership Leave of Absence}
-An Active member may at any time request a leave of absence using the process described in \ref{Leave of Absence}.
-For the duration of an absence, a member:
-\begin{itemize}
-	\item Forfeits their right to vote
-	\item Does not count towards quorum
-	\item Will not be required to attend House Meeting
-\end{itemize}
-\asubsection{Active Membership Resignations}
-An Active member may resign by submitting, in writing, the reason for resignation to the Chairperson, or Evaluations Director.
+
+\begin{description}
+	\item[Qualifications:] Students currently enrolled at the Rochester Institute of Technology who have passed the Introductory Evaluation and their most recent Membership Evaluation
+	\item[Selection:] Alumni Members in good standing may self-select into Active Membership by paying dues to the Financial Director and notifying the Evaluations Director. Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become an Active Member by notifying the Evaluations Director of their intent to participate, who will bring them up for a Simple Majority vote at the next House meeting. If the vote passes the Alumni is reinstated as an Active Member with Off-Floor status effective immediately.
+	\item[Expectations:]  Be an active participant in the House as defined in \ref{Expectations of House Members}
+	\item[Privileges:]  Active members receive the privelege to:
+		\begin{itemize}
+			\item Vote on all issues brought before the House
+			\item Reside on the House
+			\item Hold an Executive Board office on the House
+			\item Use Computer Science House facilities
+			\item Attend Computer Science House functions
+			\item Receive priority for available housing on the House when returning from cooperative education
+			\item Guaranteed housing in compliance with the Residence Life policies regarding Special Interest Houses and the Housing Selection Process (if they have On-Floor status)
+		\end{itemize}
+Active Members currently on co-op forfeit their right to vote on house issues, and likewise do not count towards quorum. Exceptions may be made at the discretion of the Evaluations Director.
+	\item[Evaluations:] Active Members are evaluated annually through the Evaluation Process as described in \ref{Evaluations Processes}.
+	\item[Leave of Absence:] An Active member may at any time request a leave of absence using the process described in \ref{Leave of Absence}. For the duration of an absence, a member:
+		\begin{itemize}
+			\item Forfeits their right to vote
+			\item Does not count towards quorum
+			\item Will not be required to attend House Meeting
+		\end{itemize}
+	\item[Resignations:] An Active member may resign by submitting, in writing, the reason for resignation to the Chairperson, or Evaluations Director.
 Instead of forfeiting membership, Active members who resign may elect to become Alumni defined in \ref{Alumni Membership Selection}.
 The resignation will take effect immediately and an announcement will be made at the following House Meeting.
-\asubsection{Active Membership Term}
-Active Membership shall last until the member resigns or changes membership status.
+	\item[Term:] Active Membership shall last until the member resigns or changes membership status.
+\end{description}
+
 
 \asection{Alumni Membership}
-\asubsection{Alumni Membership Qualifications}
-Alumni Membership is open to all former Active members of Computer Science House who passed at least one Membership Evaluation and departed for reasons other than revocation of House Membership.
-\asubsection{Alumni Membership Selection}
-Active members who depart house (i.e. resign) after passing the current operating session's Membership Evaluations are considered to be Alumni in good standing.
-\\*\\*
-Active members who depart house without passing the current operating session's Membership Evaluations are considered to be Alumni in bad standing.
-This may be appealed to the Executive Board in order to pursue a different outcome.
-\asubsection{Alumni Membership Expectations}
-There are no expectations associated with the Alumni Membership status.
-\asubsection{Alumni Membership Privileges}
-Alumni Members shall receive the right to:
-\begin{itemize}
-	\item Use Computer Science House facilities
-	\item Attend Computer Science House functions
-\end{itemize}
-\asubsection{Alumni Membership Evaluations}
-Alumni Members are not subject to any evaluation.
-\asubsection{Alumni Membership Resignations}
-There are no resignations associated with Alumni Membership status.
-\asubsection{Alumni Membership Term}
-Alumni Membership shall last indefinitely or until the member chooses to pursue Active Membership.
+
+\begin{description}
+	\item[Qualifications:] All former Active Members who passed at least one Membership Evaluation and departed for reasons other than revocation of House Membership
+	\item[Selection:] Active members who depart house (i.e. resign) after passing the current operating session's Membership Evaluations are considered to be Alumni in good standing. Active members who depart house without passing the current operating session's Membership Evaluations are considered to be Alumni in bad standing. This may be appealed to the Executive Board in order to pursue a different outcome.
+	\item[Expectations:] None
+	\item[Privileges:] Use Computer Science House facilities and attend Computer Science House functions
+	\item[Evaluations:] None
+	\item[Resignations:] None
+	\item[Term:] Indefinite, or until the member chooses to pursue Active Membership.
+\end{description}
 
 \asection{Honorary Membership}
-\asubsection{Honorary Membership Qualifications}
-Honorary Membership is open to a person whom the House feels has contributed great personal effort to the House and is deserving of House recognition.
-\asubsection{Honorary Membership Selection}
-Any House member may nominate a candidate for Honorary Membership by submitting the name in writing to the Evaluations Director.
-The Evaluation Director then begins the Honorary Membership Selection Process as defined in \ref{Selection Process for Honorary Members}
-\asubsection{Honorary Membership Expectations}
-Honorary Members are encouraged to remain in contact with the House.
-\asubsection{Honorary Membership Privileges}
-Honorary Members may advise in all issues brought before the House, use Computer Science House facilities, and attend Computer Science House functions.
-\asubsection{Honorary Membership Evaluations}
-Honorary Members are not subject to formal evaluations.
-\asubsection{Honorary Membership Resignations}
-An Honorary Member may resign by submitting in writing the reason for resignation to the Chairperson.
-The resignation will be read at the following House Meeting and become effective at that time.
-\asubsection{Honorary Membership Term}
-Honorary Membership shall last until the member resigns.
+
+\begin{description}
+	\item[Qualifications:] Any person whom the House feels has contributed great personal effort to the House and is deserving of House recognition
+	\item[Selection:] Any House member may nominate a candidate for Honorary Membership by submitting the name in writing to the Evaluations Director. The Evaluation Director then begins the Honorary Membership Selection Process as defined in \ref{Selection Process for Honorary Members}
+	\item[Expectations:] Encouraged to remain in contact with the House
+	\item[Privileges:] Advise in all issues brought before the House, use Computer Science House facilities, and attend Computer Science House functions.
+	\item[Evaluations:] None
+	\item[Resignations:]  Submit the reason for resignation to the Chairperson. The resignation will be read at the following House Meeting and become effective at that time.
+	\item[Term:] Lasts until the member resigns
+\end{description}
 
 \asection{Advisory Membership}
-\asubsection{Advisory Membership Qualifications}
-Advisory Membership is open to all members of the Rochester Institute of Technology professional, academic, or administrative staff.
-\asubsection{Advisory Membership Selection}
-The Executive Board may open nominations for Advisory Members.
-The candidates then participate in the Advisory Selection Process as defined in \ref{Selection Process for Advisory Members}
-\asubsection{Advisory Membership Expectations}
-Advisors are encouraged to offer advice and assistance to the House in any capacity the Advisor is able to help.
-Advisors are also encouraged to meet the House members and occasionally attend House activities.
-\asubsection{Advisory Membership Privileges}
-Advisory Members may advise in all issues brought before the House, use Computer Science House facilities, and attend Computer Science House functions.
-\asubsection{Advisory Membership Evaluations}
-Advisors are not subject to formal evaluations.
-\asubsection{Advisory Membership Resignations}
-An Advisor may resign by submitting in writing the reason for resignation to the Chairperson.
-The resignation will be read at the following House Meeting and become effective at that time.
-\asubsection{Advisory Membership Term}
-Advisory Membership shall last until the member resigns.
+
+\begin{description}
+	\item[Qualifications:] Be a member of the Rochester Institute of Technology professional, academic, or administrative staff.
+	\item[Selection:] The Executive Board may open nominations for Advisory Members. The candidates then participate in the Advisory Selection Process as defined in \ref{Selection Process for Advisory Members}
+	\item[Expectations:] Advisors are encouraged to offer advice and assistance to the House in any capacity the Advisor is able to help. Advisors are also encouraged to meet the House members and occasionally attend House activities.
+	\item[Privileges:] Advise in all issues brought before the House, use Computer Science House facilities, and attend Computer Science House functions.
+	\item[Evaluations:] None
+	\item[Resignations:] Submit the reason for resignation to the Chairperson. The resignation will be read at the following House Meeting and become effective at that time.
+	\item[Term:] Lasts until the member resigns
+\end{description}
 
 \asection{Leave of Absence}
 A leave of absence offers the option for members to take extended time away from their responsibilities to House for any number of personal issues including, but not limited to, physical illness, mental illness, or care giving for a sick family member.


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Resolves #76 by restructuring the membership sections based on discussion in recent meeting.
