### PR TITLE
Add miniasubsection formatting for Membership

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -40,6 +40,12 @@
 \titleformat{\section}{\normalfont\Large\bfseries}{Article \thesection}{1em}{}
 \titleformat{\subsection}{\normalfont\large\bfseries}{Section \thesubsection}{1em}{}
 
+% These set up an environment that will remove the newline after \asubsections
+% use \begin{miniasubsections}
+\newcommand{\miniasubsectionson}{\titleformat{\subsubsection}[runin]{\normalfont\normalsize\bfseries}{\thesubsubsection}{1em}{}}
+\newcommand{\normalasubsections}{\titleformat{\subsubsection}{\normalfont\normalsize\bfseries}{\thesubsubsection}{1em}{}}
+\newenvironment{miniasubsections}[0]{\miniasubsectionson}{\normalasubsections}
+
 % Adding an \asubsubsection -- I feel dirty
 %\setcounter{secnumdepth}{5}
 \newcommand{\asubsubsection}[1]{\paragraph{#1} \label{#1}}
@@ -143,6 +149,7 @@ Unless explicitly stated otherwise, the requirements and expectations defined in
 
 % ARTICLE IV - MEMBERSHIP
 \article{Membership}
+\begin{miniasubsections}
 There are five major types of membership available to Computer Science House.
 Each carries different qualifications, expectations, and privileges.
 When describing the different memberships available, the following terms are used:
@@ -301,6 +308,7 @@ A member may request their evaluation period to be extended by the duration of t
 The duties and responsibilities of an Executive Board Member on leave are assumed using the process defined in Section \ref{Appointment of an Interim Director} until the member returns from their leave.
 Upon returning, the member may assume their position and the interim director is removed.
 If at any point the member's leave is determined by the Executive Board to be detrimental to the operations of house, any Executive Board member may propose a two-thirds vote amongst the Executive Board to require a resignation from the Member.
+\end{miniasubsections}
 
 % ARTICLE V - EXECUTIVE BOARD
 \article{Executive Board}


### PR DESCRIPTION
Experiment with removing the newline after \asubsection usages in an environment

I personally think this hampers readability, but feel free to play around with it

Output as of 2114f9cdfcc9bc8580ad941bfa48b09a0c133679: https://csh.rit.edu/~mom/mini-asubsections-2023-oct-31-1422.pdf

Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.


