### PR TITLE
Resolves #127 Condense 5.D.1.B

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -802,10 +802,8 @@ The following process is used for making changes to the Code of Conduct document
 The amount of dues for Active Members will be eighty dollars (\$80.00) per Academic Semester.
 \asubsection{Collection of House Dues}
 The collection period of house dues will be decided in conjunction with The Center for Residence Life and Housing Operations.
-During the dues collection period, dues for on-floor members (for both semesters) are collected through the member’s RIT bill.
-Dues for off-floor members are to be collected during this period as well by the Financial Director.
-For any member who moves on or off-floor during the year, any difference between dues paid and dues owed should be collected.
-Dues for any alumnus/alumnae in good standing are to be collected when intention to pay is expressed to the Financial Director.
+During the dues collection period, dues for both semesters for all Active Members are collected through the member's RIT bill.
+Dues for any Alumni Member in good standing are to be collected when intention to pay is expressed to the Financial Director.
 \asubsubsection{Rules for Giving Exceptions and Exemptions for House Dues}
 If a member is unable to pay dues upon request, they may appeal their situation to the Financial Director.
 If the Financial Director deems their situation appropriate, they may grant specific extensions or reductions of the member's payment as they see fit.


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Resolves #127  by rewording 5.D.1.B to reflect the fact that dues are equivalent for on-floor and off-floor members.