### PR TITLE
Changed last bullet point in 5.F.1 to reflect best practice

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -783,7 +783,7 @@ The following special cases cover the operation of a dual directorship:
 	\item During an official Executive Board Vote, each dual directorship member's vote counts for one-half vote in the tallying of votes.
 		The members of the dual directorship need not vote the same way in a vote.
 	\item A member of a dual directorship may not hold any other Executive Board position.
-	\item When attendance requirements call for the dual directorship position to be present, both dual directorship members are to fulfill the requirements.
+	\item When attendance requirements call for the dual directorship position to be present, at least one of the members of the dual directorship is to fulfill the requirements.
 \end{itemize}
 \asubsection{Selection of the Chairperson, Evaluations Director, Social Director(s), Financial Director, House Improvements Director, House History Director, Research and Development Director(s), Public Relations Director}
 \begin{enumerate}


### PR DESCRIPTION
…o members has to be present

Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

changed one line so that only one of the two members of the dual has to be present. Made this section reflect current practice.