### PR TITLE
resolve #13 reorganize sections

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -93,49 +93,6 @@ The objectives of Computer Science House are:
 \asection{Constitution}
 The House Constitution is written and maintained by the House and defines the major aspects, goals, and governing structure of the house.
 
-\asubsection{Non-Semantic Changes}
-There are two methods for non-semantic change to the Constitution.
-A Maintainer may approve any proposed change that does not affect the meaning of the document.
-Alternatively, the change may be presented to the House for discussion followed by an Immediate Vote.
-A quorum of fifty percent of the Total Number of Possible Votes is required for passage.
-
-\asubsection{Semantic Changes}
-Any semantic change to the Constitution requires the change to be proposed in writing for discussion at a House Meeting.
-Any modifications made due to the discussion are added to the written proposal and the modified proposal is posted in the House during the week.
-The final proposal is presented the following week and ballots are distributed for a ballot House vote as described in \ref{Balloted Vote}.
-The ballots are collected for a minimum of a forty-eight hour period.
-A quorum of two-thirds of the Total Number of Possible Votes must cast ballots for the vote to be official.
-A vote equaling or exceeding two-thirds of the number of votes cast is required for the change to be placed into the constitution.
-The Constitution may be overridden by an immediate House vote as described in \ref{Immediate Vote}.
-There must be a quorum of eighty-five percent of the Total Number of Possible Votes for the vote to be official.
-A vote equaling or exceeding ninety percent of the number of votes cast is required for the override to take effect.
-
-\asection{Maintainers}
-
-\asubsection{Maintainer Qualifications}
-Maintainers must be Active or Alumni Members.
-
-\asubsection{Maintainer Expectations}
-Maintainers are expected to:
-\begin{itemize}
-	\item Be knowledgeable about the Constitution
-	\item Review changes to the Constitution for grammar, spelling, and internal consistency
-	\item Participate in discussion of proposals and amendments
-	\item Keep a public record of changes to the Constitution
-\end{itemize}
-Failure to meet any of these expectations is grounds for revocation of Maintainer status by the Executive Board.
-
-\asubsection{Maintainer Term}
-Maintainer status lasts until it is resigned, or until it is revoked by Executive Board vote.
-A Maintainer may resign at any time by notifying the current Executive Board and Maintainer group.
-If a Maintainer no longer satisfies \ref{Maintainer Qualifications}, they lose Maintainer status.
-
-\asubsection{Maintainer Selection}
-Any member may nominate a qualified member for Maintainer status to the Executive Board for consideration.
-The Executive Board may choose to approve or reject the nomination by Simple Majority vote with a quorum of seventy-five percent of the Total Number of Possible Votes.
-
-% ARTICLE III - GENERAL OPERATIONS OF THE HOUSE
-\article{General Operations of the House}
 \asection{Standard Operating Session}
 The Standard Operating Session for Computer Science House is during the Fall and Spring semesters.
 The Summer Sessions, Intersessions, Institute breaks, and all end of Semester Exam Weeks are considered non-standard operating sessions.
@@ -163,13 +120,97 @@ Introductory Membership is open to all students at the Rochester Institute of Te
 \asubsection{Introductory Membership Selection}
 Applicants notify the House of their interest in membership by submitting an application to the Evaluations Director.
 They must then undergo the selection process as defined in \ref{Selection Processes}.
+
+\asubsubsection{Selection Processes}
+\renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
+
+% Current RIT students is defined as students who have attended RIT for at least 1 full semester
+\asubsubsubsection{Selection Process for Current RIT Students}
+\begin{enumerate}
+	\item The applicant submits an application to the Evaluations Director for review.
+	\item The applicant participates in an informal interview with exactly three current Active, Alumni, or Honorary Members.
+	\item The application materials are then reviewed at an Evaluations meeting.
+	Then a simple majority vote, of attending members, is held on whether or not to accept the person as an Introductory Member.
+\end{enumerate}
+Note: Most membership privileges do not initiate until successful completion of the introductory process.
+This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
+The member does, however, have the right to use Computer Science House's facilities.
+The member is not required to pay dues during the Introductory Process.
+\\* \\*
+Additional Note: No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
+
+% Incoming RIT students is defined as students who have attended RIT for less than 1 full semester
+\asubsubsubsection{Selection Process for Incoming RIT Students}
+\begin{enumerate}
+	\item During Spring semester, the Evaluations Director selects a group of Active Members to form a Selections Committee.
+		The Selections Committee reviews applications and conducts interviews in accordance with the process prescribed by Residence Life.
+        \item A subset of applicants will be offered Introductory Membership and must participate in the Introductory Process defined in \ref{The Introductory Process}. 
+            A subset of Introductory Members will be offered On-Floor status and will be able to select a room on floor. 
+            The other Introductory Members will have Off-Floor status, but will otherwise have the same privileges and responsibilities.
+\end{enumerate}
+Note: Most membership privileges do not initiate until successful completion of the introductory process.
+This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
+The member does, however, have the right to use Computer Science House's facilities.
+The member is not required to pay dues during the Introductory Process.
+\\* \\*
+Additional Note: No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
+
 \asubsection{Introductory Membership Expectations}
 Introductory members are expected to meet all the requirements of the Introductory Process, as described in \ref{Expectations of an Introductory Member}.
 \asubsection{Introductory Membership Privileges}
 Introductory members receive the right to use Computer Science House facilities, to attend House functions, and to have housing priority over all persons who are not Computer Science House members.
 \asubsection{Introductory Membership Evaluations}
-Introductory members are evaluated on their performance during the introductory period.
-The introductory evaluation process is described in \ref{Introductory Evaluation}.
+\asubsection{The Introductory Process}
+The Introductory Process is designed to provide an easy means for Introductory Members to meet existing House members, learn House history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
+\asubsection{The Evaluation Period}
+The Process will occur either once or twice per semester, and will last for six (6) weeks.
+The Process shall be initiated by the Evaluations Director during either the first and second week of each semester.
+The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
+If an Introductory Process is extended, the Introductory Evaluation shall occur at the termination of the extended Process, which may be outside of the period defined in \ref{Introductory Evaluation}.
+If deemed necessary by the Evaluations Director, or by an Executive Board simple majority vote, the second intro process must begin within nine (9) days of the first process ending.
+If a second Introductory Process is approved, the Evaluations Director may initiate a new Introductory Packet within the first or second week of the Introductory Process.
+\asubsection{The Introductory Packet}
+Each Introductory Process participant, after the first week, is given two (2) weeks to obtain signatures from all Active Members who have passed a Membership Evaluation, all On-Floor Introductory Members, and ten (10) of any combination of the following:
+\begin{itemize}
+	\item Alumni members
+	\item Honorary members
+	\item Advisory members
+\end{itemize}
+At the discretion of the Evaluations Director, any Introductory Packet may be extended to accommodate extenuating circumstances.
+\asubsubsection{Expectations of an Introductory Member}
+Before the end of the Process, an Introductory Member is expected to:
+\begin{itemize}
+\item Attend all House meetings during the process
+\item Complete the Introductory Packet
+\item Attend at least one House directorship meeting for each week of the process (including permanent and Ad Hoc directorship meetings)
+\item Attend at least one House social event during the process
+\item Attend at least two seminars relating to computing or electronics
+\item Sign a copy of the Membership Agreement describing a House Member’s responsibilities and expectations
+\end{itemize}
+
+\asubsubsection{Introductory Evaluation}
+The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of Active Membership.
+It occurs at the conclusion of the final week of the Process.
+
+\asubsubsubsection{Voting}
+On a member by member basis, this evaluation process determines if each Introductory member has successfully completed the Introductory Process requirements \ref{Expectations of an Introductory Member}.
+A Simple Majority vote with a quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.
+In order for an Active Member to be counted as a Possible Vote they must meet the requirements outlined in \ref{Expectations of Voting Members}.
+Neither absentee nor proxy votes are allowed.
+House may choose any of the Outcomes for each member.
+
+\asubsubsubsection{Outcomes}
+\renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
+\begin{enumerate}
+	\item Introductory Members may be offered Active Membership (\ref{Active Membership}) provided they meet the requirements described in \ref{Expectations of an Introductory Member}, at the discretion of House.
+	\item If an Introductory Member fails to meet the requirements, their membership will be revoked.
+	\item An Introductory member may be given a conditional to complete as a means of making up for missing requirements.
+		A conditional may be proposed by any member present at the Introductory Evaluation and, if it is approved by the Evaluations Director, is then voted on by House.
+		Each conditional consists of a set of additional requirements and a deadline for completing them.
+		When the deadline expires, the conditional will be brought before the Executive Board who will assess its completeness.
+		A conditional member who does not meet these additional requirements forfeits membership.
+\end{enumerate}
+
 \asubsection{Introductory Membership Leave of Absence}
 After completion of the Introductory Packet, an Introductory member may request a leave of absence through the process described in \ref{Leave of Absence}.
 \asubsection{Introductory Membership Resignations}
@@ -187,6 +228,17 @@ Any Alumni Member in bad standing (\ref{Alumni Membership Selection}) may become
 If the vote passes the Alumni is reinstated as an Active Member effective immediately.
 \asubsection{Active Membership Expectations}
 Active members are expected to be active participants in the House as defined in \ref{Expectations of House Members}.
+Active voting members are expected to meet the requirements defined in \ref{Expectations of Voting Members}.
+
+\asubsubsection{Expectations of House Members}
+Active members are required to pay House dues as stated in \ref{Collection of House Dues}, attend all House Meetings and Executive Board candidate speeches, and attend at least fifteen (15) of the House directorship meetings (including permanent and Ad Hoc directorship meetings) for each Academic Semester in which they are an Active Member.
+\\* \\*
+Active members must participate significantly in at least one major project during the academic year.
+Members are required to submit a description for this major project to the Executive Board for approval.
+As an option to this requirement, members may instead assist on a large number of House activities and projects.
+However, it is to be understood in advance by the member that this option requires a great deal of participation throughout the year.
+This participation will be evaluated by the Executive Board.
+
 \asubsection{Active Membership Privileges}
 Active Members receive the privilege to:
 \begin{itemize}
@@ -198,8 +250,59 @@ Active Members receive the privilege to:
 	\item Receive priority for available housing on the House when returning from cooperative education
 	\item Guaranteed housing in compliance with the Residence Life policies regarding Special Interest Houses and the Housing Selection Process (if they have On-Floor status)
 \end{itemize}
+\asubsubsection{Expectations of Voting Members}
+The following requirements must be met by the beginning of the Introductory Evaluation for an Active Member to be allowed to vote. 
+Any of these requirements may be waived by the Evaluations Director or a simple majority vote by the Executive Board
+\begin{itemize}
+\item Attend all House meetings during the process
+\item Attend at least one House directorship meeting for each week of the process (including permanent and Ad Hoc directorship meetings)
+\item Attend at least one House social event during the process
+\item Attend at least two seminars relating to computing or electronics
+\end{itemize}
 \asubsection{Active Membership Evaluations}
 Active Members are evaluated annually through the Evaluation Process as described in \ref{Evaluations Processes}.
+
+% ACTIVE MEMBERSHIP EVALUATIONS
+
+\asubsubsection{Evaluations Processes}
+During the academic year, a House member is evaluated by the Membership Evaluation.
+The Membership Evaluation is responsible for determining those individuals who will have the option to continue Active Membership in the following year.
+Semi-Annual Evaluations Meetings are open only to current Active Members.
+All Executive Board members are expected to attend the Semi-Annual Evaluations Meetings to assist in the evaluations of House members.
+\\* \\*
+At the beginning of any Evaluation Process listed herein, the Evaluations Director must read the sections of the Computer Science House Constitution used during the respective Evaluation Process.
+It is incumbent upon each House member to provide the Evaluation Director with whatever information they feel is necessary to ensure an accurate evaluation.
+\asubsubsubsection{Membership Evaluation}
+The Membership Evaluation process occurs once per academic year.
+It is performed as part of the Evaluation Process that takes place during the spring semester to comply with RIT Housing deadlines.
+\asubsubsubsubsection{Voting}
+Any Active Member who has completed all of the requirements as defined in \ref{Expectations of House Members} at the beginning of the Membership Evaluation passes their Membership Evaluation without being voted on or evaluated by the quorum.
+All Active Members who have not recieved an exemption from the Executive Board prior to the Membership Evaluation will be evaluated on a Member by Member basis by a quorum of Active Members.
+The Membership Evaluation shall hold members to the objective requirements defined in \ref{Expectations of House Members} and determine which members may continue as an Active Member in the following Standard Operating Session.
+Exceptions to the requirements may be made, as House may choose any of the Outcomes for each Member, even if the Member being evaluated has not completed all of their requirements.
+These requirements must be completed before the Membership Evaluation occurs.
+A Secret Immediate Simple Majority vote with a Quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.
+Neither absentee nor proxy votes are allowed.
+
+
+\asubsubsubsubsection{Outcomes}
+Members who pass Membership Evaluation have the option to participate as an Active Member in the following year and remain on the upcoming roster if applicable.
+\\* \\*
+If a member fails and has never passed a Membership Evaluation in the past, their membership will be revoked immediately.
+If the member has previously passed a Membership Evaluation they will move to Alumni Membership status at the end of the Standard Operating Session (\ref{Alumni Membership Selection}).
+In either case, the member forfeits their ability to be included on the following year’s roster.
+\\* \\*
+A member may be given a conditional to complete as a means of making up for missing requirements.
+A conditional may be proposed by any member present at the Evaluation.
+If the conditional is approved by the Evaluations Director, it is then voted on by House.
+Each conditional consists of a set of additional requirements a deadline for completing them.
+When the deadline expires, the conditional will be brought before the Executive Board who will assess its completeness.
+A conditional member who does not meet these additional requirements will have failed the evaluation.
+\asubsubsubsection{Appeals Process}
+If a member disagrees with the outcome of any evaluation, (e.g. is not asked to return to the House for the following year) and wishes to appeal the decision, they may do so as stated in \ref{Appeals}.
+\\* \\*
+If the member is still unsatisfied after being heard by the Executive Board, the appeal may be brought to the attention of the ResLife Advisor.
+
 \asubsection{Active Membership Leave of Absence}
 An Active member may at any time request a leave of absence using the process described in \ref{Leave of Absence}.
 For the duration of an absence, a member:
@@ -273,8 +376,9 @@ Honorary and Advisory Memberships shall last until the member resigns.
 A Leave of Absence offers the option for members to take extended time away from their responsibilities to House for any number of personal issues including, but not limited to, physical illness, mental illness, or care giving for a sick family member. 
 In order to request a Leave of Absence, a member must follow the RIT policy for Leave of Absence, located at \url{https://www.rit.edu/policies/d021}. Additionally, the member should notify the Evaluations Director of their Leave, at which point they become exempt from all House requirements until they return.
 
-% ARTICLE V - EXECUTIVE BOARD
-\article{Executive Board}
+% ARTICLE V - OFFICERS OF THE HOUSE
+\article{Officers of the House}
+\asection{Executive Board}
 The Executive Board is the main governing body of the House.
 Its purpose is to provide leadership and direction for the House, to oversee the day-to-day operations of the House, and to initiate and organize programs and projects for the House.
 \\*\\*
@@ -284,10 +388,10 @@ They are generally very task oriented and are chaired by a House member.
 A directorship has some jurisdiction in its area of interest and often is responsible for the day-to-day decisions regarding its area of interest.
 Any large expenditures or large effect decisions must be brought before the entire House
 
-\asection{Responsibilities}
+\asubsection{Responsibilities}
 
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
-\asubsection{Responsibilities of the Executive Board}
+\asubsubsection{Responsibilities of the Executive Board}
 \begin{enumerate}
 	\item To hold a weekly meeting specific to their responsibilities and submit notes to the House
 	\item To meet, as an Executive Board, at least weekly during the Standard Operating Session, as defined in \ref{Standard Operating Session} to discuss and report the operations of the House
@@ -302,7 +406,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 		The constitution should remain up to date with current practices.
 \end{enumerate}
 
-\asubsection{Responsibilities of the Chairperson}
+\asubsubsection{Responsibilities of the Chairperson}
 \begin{enumerate}
 	\item To preside over Executive Board and House Meetings
 	\item To exercise general supervision over the operations of the Executive Board
@@ -312,7 +416,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To cast tie-breaking vote in a split decision in an Executive Board vote
 \end{enumerate}
 
-\asubsection{Responsibilities of the Evaluations Director}
+\asubsubsection{Responsibilities of the Evaluations Director}
 \begin{enumerate}
 	\item To preside over Evaluations Meetings
 	\item To exercise general supervision over Evaluations operations
@@ -324,7 +428,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
-\asubsection{Responsibilities of the Social Director(s)}
+\asubsubsection{Responsibilities of the Social Director(s)}
 \begin{enumerate}
 	\item To preside over Social Meetings in which House members are encouraged to bring ideas for social events
 	\item To exercise general supervision over Social operations
@@ -333,7 +437,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
-\asubsection{Responsibilities of the Public Relations Director}
+\asubsubsection{Responsibilities of the Public Relations Director}
 \begin{enumerate}
 	\item To preside over Public Relations Directorship Meetings
 	\item To operate House social media accounts intended to represent House as a whole
@@ -344,7 +448,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 
 \end{enumerate}
 
-\asubsection{Responsibilities of the Financial Director}
+\asubsubsection{Responsibilities of the Financial Director}
 \begin{enumerate}
 	\item To preside over Financial Meetings in which House members are encouraged to bring ideas for fund-raising activities
 	\item To supervise financial administrators and transactions involving house projects
@@ -357,7 +461,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
-\asubsection{Responsibilities of the Research and Development Director(s)}
+\asubsubsection{Responsibilities of the Research and Development Director(s)}
 \begin{enumerate}
 	\item To preside over Research and Development Meetings in which House members are encouraged to bring ideas for projects
 	\item To exercise general supervision over Research and Development operations
@@ -367,7 +471,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
-\asubsection{Responsibilities of the House Improvements Director}
+\asubsubsection{Responsibilities of the House Improvements Director}
 \begin{enumerate}
 	\item To preside over House Improvements Meetings
 	\item To exercise general supervision over the House Improvements operations
@@ -376,14 +480,14 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
-\asubsection{Responsibilities of the Operational Communications Director}
+\asubsubsection{Responsibilities of the Operational Communications Director}
 \begin{enumerate}
 	\item To represent the Root Type Persons at Executive Board Meetings and at House Meetings
 	\item To report the status of the House computer systems and network to the Executive Board and House members
 	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
-\asubsection{Responsibilities of the House History Director}
+\asubsubsection{Responsibilities of the House History Director}
 \begin{enumerate}
 	\item To preside over House History Meetings
 	\item To exercise general supervision over the House History operations
@@ -394,7 +498,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
-\asubsection{Responsibilities of the House Secretary}
+\asubsubsection{Responsibilities of the House Secretary}
 \begin{enumerate}
 	\item To ensure that minutes are recorded and posted for Executive Board Meetings
 	\item To ensure that minutes are recorded and posted for House Meetings
@@ -403,286 +507,191 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To record all votes cast during House Meetings and Open Executive Board Meetings
 \end{enumerate}
 
-\asubsection{Responsibilities of Ad Hoc Directorships}
+\asubsubsection{Responsibilities of Ad Hoc Directorships}
 \begin{enumerate}
 	\item Ad Hoc Directorships are responsible for the task for which they were created
 	\item Any responsibilities budgets or finances for the Ad Hoc Directorship are placed upon the assigned director
 \end{enumerate}
 
-\asection{Closed Executive Board}
+\asubsection{Closed Executive Board}
 Closed Executive Board Meetings are open only to the Chairperson, Voting Members of the Executive Board, and those with the express permission of the Executive Board.
 A closed Executive Board meeting may be called at any time by any member of the Executive Board.
 However, the Chairperson and at least two-thirds of the Voting Members of the Executive Board must be present for the meeting to be called.
 
-\asection{Operations}
-\asubsection{Operations of the Financial Directorship}
-\asubsubsection{Amount of House Dues}
-The amount of dues for Active Members will be eighty dollars (\$80.00) per Academic Semester.
-\asubsubsection{Collection of House Dues}
-The collection period of house dues will be decided in conjunction with The Center for Residence Life and Housing Operations.
-During the dues collection period, dues for on-floor members (for both semesters) are collected through the member’s RIT bill.
-Dues for off-floor members are to be collected during this period as well by the Financial Director.
-For any member who moves on or off-floor during the year, any difference between dues paid and dues owed should be collected.
-Dues for any alumnus/alumnae in good standing are to be collected when intention to pay is expressed to the Financial Director.
-\asubsubsubsection{Rules for Giving Exceptions and Exemptions for House Dues}
-If a member is unable to pay dues upon request, they may appeal their situation to the Financial Director.
-If the Financial Director deems their situation appropriate, they may grant specific extensions or reductions of the member's payment as they see fit.
-If the Financial Director deems their situation inappropriate for extension, the member may appeal to the Executive Board.
-If the Executive Board disagrees with the Financial Director, the Executive Board may reduce the required payment or extend the payment deadline.
-If the Executive Board agrees with the Financial director, the member’s payment is considered delinquent and the member’s privileges are revoked until payment can be made.
-In the case the Financial Director or Executive Board decides the situation is appropriate, the member's dues may be partially or fully excused, or the member may be given additional time to pay their dues. 
-Additional time and reduction of dues may both be given to a member in an appropriate situation.
-All dues must be collected in full before the annual membership evaluation (\ref{Membership Evaluation}).
-After this date, dues collection is suspended until the start of the next academic year.
-\asubsubsection{Breakdown of Dues for Directorship Budgets}
-\begin{center}
-\begin{tabular}[c]{|l c|}
-\hline
-Directorship Name & Percentage of Dues \\
-\hline
-\hline
-Operational Communications & 20\% \\
-\hline
-Evaluations & 5\% \\
-\hline
-House History & 10\% \\
-\hline
-House Improvements & 15\% \\
-\hline
-Research and Development & 20\% \\
-\hline
-Social & 20\% \\
-\hline
-Public Relations & 5\% \\
-\hline
-Accumulated & 5\% \\
-\hline
-\end{tabular}
-\end{center}
+\asubsection{Qualifications}
+\asubsubsection{Qualifications to be the Chairperson, Evaluations Director}
+\begin{enumerate}
+	\item Candidates must be Active Members during the term of office
+	\item Candidates must reside on floor during the term of office
+	\item Candidates must have at least one full semester of House membership as an Active Member
+	\item Elected or selected candidates may not hold a simultaneous voting Executive Board position, and must therefore resign their current position, or the position of Chairperson, should they be elected
+\end{enumerate}
+\asubsubsection{Qualifications to be the Social Director(s), Financial Director, Research and Development Director(s), House Improvements Director, House History Director, Public Relations Director}
+\begin{enumerate}
+	\item Candidates must be Active Members during the term of office
+	\item Candidates must have at least one full semester of House membership as an Active Member
+	\item Elected or selected candidates may not hold two simultaneous voting Executive Board positions, and must therefore resign their current position or decline a second position should they be elected or selected to a second voting position
+\end{enumerate}
+\asubsubsection{Qualifications to be the Operational Communications Director}
+\begin{enumerate}
+	\item Candidates must be a current Root Type Person \ref{Operations of the Operational Communications Directorship}.
+	\item Candidates must be a current Active Member.
+	\item A Root Type Person cannot be the director if they currently hold any other voting Executive Board Position.
+\end{enumerate}
 
-% The suggested total operating budget is $8360.
-% This figure comes from having approximately 55 on-floor members with $80 per semester dues (totaling $8800) minus 5% set aside for Accumulated.
+\asubsubsection{Qualifications to be the House Secretary or an Ad Hoc Director}
+\begin{enumerate}
+\item Candidates must be Active Members
+\end{enumerate}
 
-Dues collected from on-floor members are to be distributed into directorship budgets as shown in the above table.
-Money allocated for Accumulated or collected from off-floor members is deposited into the CSH Account and saved.
+\asubsubsection{Waiving of Qualifications}
+\begin{enumerate}
+  \item House may choose to waive the following subset of the Qualifications for Executive Board positions (defined under \ref{Qualifications}) for all Candidates:
+    \begin{enumerate}
+      \item Candidates must reside on floor during the term of office.
+      \item Candidates must have at least one full semester of House membership as an Active Member.
+      \item Social and Research and Development are the only voting Executive Board positions that allow for Dual Directorship.
+    \end{enumerate}
+  \item When a waiver is proposed, the Chair of the Vote shall state which Executive Board position and Qualification is being voted upon, and any nominated Candidates not qualified under \ref{Qualifications} who would become qualified if the waiver passes.
+  \item A Three-Quarters Immediate Vote, as defined in \ref{Three-Quarters} and \ref{Immediate Vote}, is then taken to determine whether the proposed waiver shall take effect.
+  \item Each vote to waive a Qualification must only apply to a single Qualification for a single Executive Board position.
+  \item Waivers always apply to all Candidates for the Executive Board position.
+\end{enumerate}
 
-\asubsubsection{Expenditure Approval}
-All House expenditures must be approved by both the Financial Director and the appropriate Director (from whose budget the funds will be drawn).
-Single expenditures may not exceed seventy-five dollars (\$75) and total expenditures may not exceed one-hundred dollars (\$100).
-A total expenditure is defined as all the funds drawn for a specific event, project, piece of equipment, or service.
-\\* \\*
-If the above amounts are to be exceeded, the expenditure must be approved by a Simple Majority vote at House meeting before the funds may be appropriated, as defined in \ref{Simple Majority}.
-At the Financial Director's discretion, a Spending Committee meeting may be held in order to approve any purchase exceeding one-hundred dollars (\$100), but not to exceed three-hundred dollars (\$300).
-A quorum of one-quarter the number of current active members is required for the meeting to take place and for any vote to be considered valid, it must be passed by a simple two-thirds majority.
-\\*\\*
-For expenditures exceeding \$300 in total funding, a Complete Project Proposal must be presented to House at a House meeting.
-This proposal includes the project budget, inventory of required resources, and a timeline for completion.
-\\* \\*
-If an appropriate Directorship cannot be determined for an expenditure, it is to be brought up for approval at House meeting as a Miscellaneous expenditure and approved by a simple majority vote, regardless of the amount.
-This amount is to be directly subtracted from the general CSH account.
-\\* \\*
-Funds allocated for a project not spent by the end of the Standard Operating Session \ref{Standard Operating Session} in which they were approved are voided, unless otherwise specified during the original voting process.
+\asubsection{Selection}
+\asubsubsection{Dual Directorship}
+Social and Research and Development are the only voting Executive Board positions that allow for Dual Directorship.
+If two candidates elect to run as a Dual Directorship, their names are placed together on a single line of the election ballot.
+If they are also nominated as a normal directorship or as a dual directorship with another House member, their votes are not cumulative.
+Each different nomination must be a separate entry on the election ballot.
+Non-voting Executive Board positions (i.e. Ad Hoc Directors) are not restricted to single or dual directorship.
 
-% BY-LAW IV - OPERATIONS OF THE EVALUATIONS DIRECTORSHIP
-\asubsection{Operations of the Evaluations Directorship}
-\asubsubsection{The Introductory Process}
-The Introductory Process is designed to provide an easy means for Introductory Members to meet existing House members, learn House history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
-\asubsubsubsection{The Evaluation Period}
-The Process will occur either once or twice per semester, and will last for six (6) weeks.
-The Process shall be initiated by the Evaluations Director during either the first and second week of each semester.
-The Executive Board may hold a closed ballot Simple Majority vote to extend the Introductory Process or the Introductory Packet.
-If an Introductory Process is extended, the Introductory Evaluation shall occur at the termination of the extended Process, which may be outside of the period defined in \ref{Introductory Evaluation}.
-If deemed necessary by the Evaluations Director, or by an Executive Board simple majority vote, the second intro process must begin within nine (9) days of the first process ending.
-If a second Introductory Process is approved, the Evaluations Director may initiate a new Introductory Packet within the first or second week of the Introductory Process.
-\asubsubsubsection{The Introductory Packet}
-Each Introductory Process participant, after the first week, is given two (2) weeks to obtain signatures from all Active Members who have passed a Membership Evaluation, all On-Floor Introductory Members, and ten (10) of any combination of the following:
+The following special cases cover the operation of a dual directorship:
 \begin{itemize}
-	\item Alumni members
-	\item Honorary members
-	\item Advisory members
+	\item If one of the members in a dual directorship resigns the directorship, or for any other reason ends the term of office, the other member in the dual directorship must also step down and the office becomes vacated.
+		The vacated office is then handled like any other vacated office; see \ref{Executive Board Resignations}.
+	\item During an official Executive Board Vote, each dual directorship member's vote counts for one-half vote in the tallying of votes.
+		The members of the dual directorship need not vote the same way in a vote.
+	\item A member of a dual directorship may not hold any other Executive Board position.
+	\item When attendance requirements call for the dual directorship position to be present, both dual directorship members are to fulfill the requirements.
 \end{itemize}
-At the discretion of the Evaluations Director, any Introductory Packet may be extended to accommodate extenuating circumstances.
-\asubsubsubsection{Expectations of an Introductory Member}
-Before the end of the Process, an Introductory Member is expected to:
+\asubsubsection{Selection of the Chairperson, Evaluations Director, Social Director(s), Financial Director, House Improvements Director, House History Director, Research and Development Director(s), Public Relations Director}
+\begin{enumerate}
+	\item The opening of the Executive Board position(s) is announced at a House meeting and nominations for the position are taken for a minimum of a seventy-two hour period.
+		Any House member may nominate any member or pair of members where appropriate for a Directorship.
+	\item The candidates will be notified of their nomination.
+		Each candidate is given a minimum of twenty-four hour period to accept or decline the nomination.
+		A list of all nominees who have accepted their nominations will be posted shortly thereafter.
+	\item The date and time of candidate speeches will be announced by a member of the Executive Board at least five (5) days prior to the event. 
+		All Active Members are expected to attend candidate speeches in accordance with \ref{Expectations of House Members}.
+		If a member cannot attend due to a scheduling conflict, they may provide a reason for their absence to the Evaluations Director, who will record the reason with the absence.
+	\item Each candidate will be given an equal amount of time before the House to present their platform of candidacy.
+	\item Ballots will then be distributed and voting will be open for a minimum of a forty-eight hour period.
+		The Ballots will list, in random order, all of the candidates who are qualified for a given office with a means to indicate the selection of one of the candidates.
+		In addition, an area will be provided to indicate a write-in selection of a candidate.
+	\item At the end of the voting period, the Chairperson will terminate voting by collecting the ballot box and the votes shall be counted as stated in \ref{Alternative Vote}.
+	\item The winners are determined via the process described in \ref{Alternative Vote}.
+		A quorum of fifty-percent of the number of all members eligible to vote is required for the election to be official.
+		All winners are notified of their election.
+		If the position is currently vacant, the winner immediately assumes office.
+		If not, the winner will assume office at the end of the current term (\ref{Term}).
+		Any office whose winner declines the election, or whose winner does not fulfill the requirements of the elected office, shall have their votes redistributed in the same process as a loser in \ref{Alternative Vote}.
+\end{enumerate}
+\asubsubsection{Selection of the Operational Communications Director}
+\begin{enumerate}
+	\item A candidate for the Operational Communications Directorship shall be chosen by the current Root Type Persons.
+	\item The candidate is given a minimum of twenty-four hours to accept or decline the nomination.
+	\item The candidate is presented to the Executive Board for approval.
+		This Executive Board meeting is closed to the Executive Board Members, Root Type Persons, and House members with explicit invitation from the Executive Board.
+	\item All current Executive Board Voting Members must be present during the discussion and voting period unless that member is a candidate for the position, in which case the member is absent and their vote is abstained.
+		A simple majority Executive Board vote, as described in \ref{Simple Majority}, is taken to determine whether the candidate is selected for the position.
+\end{enumerate}
+\asubsubsection{Selection of Ad Hoc Directors}
+\begin{enumerate}
+	\item When the Executive Board or a group of House members feels an Ad Hoc Directorship is necessary, they present their plans to the Executive Board and the Executive Board decides by simple majority vote whether directorship status is granted.
+	\item When the Ad Hoc Directorship is granted status, a director is appointed, and duties, budgetary, and membership considerations are defined.
+\end{enumerate}
+\asubsubsection{Selection of the House Secretary}
+The Executive Board may choose to select a current voting Executive Board member, or to select any interested Active member, as House Secretary.
+The selection process can be an informal appointment, or follow an election process similar to other voting Executive Board positions.
+
+\asubsection{Executive Board Resignations}
+An Executive Board Member may resign their position by submitting in writing the reason for resignation to the House Chairperson.
+The resignation will be read at the following House Meeting and become effective at that time.
+The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time.
+Following a resignation, the Selection process, as defined in \ref{Selection}, of a replacement for the position vacated must begin within two weeks from when the resignation took place.
+To postpone such a Selection, the Chairperson may chair an Immediate Simple Majority Vote \ref{Immediate Vote} \ref{Simple Majority} during a House Meeting prior to the beginning of the Selection process to delay the Selection process by a specified amount of time.
+
+\asubsection{Appointment of an Interim Director}
+The duties and responsibilities of a vacated office are assumed by the Chairperson or by an Active member that is appointed at the Chairperson's discretion until the new member takes office.
+The vote of a vacated Executive Board position shall be cast as an abstention in all Executive Board matters where this vote is required to be cast.
+
+\asubsection{Impeachment}
+\begin{enumerate}
+	\item Impeachment of any Executive Board Member may be initiated by petition, in writing, consisting of a minimum number of signatures of current House members equaling or exceeding one-third the Number of Possible Votes as defined in \ref{Total Number of Possible Votes}.
+	\item The impeachment petition is then presented at an Executive Board Meeting.
+		The member(s) initiating the petition present their case to the Executive Board.
+		The Executive Board then questions the accused member of the allegations.
+	\item The Executive Board votes on the impeachment petition, with all voting members present except the accused member who must be absent and whose vote counts as an abstention, to determine if the allegations stated in the petition are legitimate grounds for impeachment.
+		If the majority of Executive Board votes are negative, the petition and impeachment proceedings are dismissed.
+		This vote may be overridden by an impeachment petition consisting of the grounds for impeachment and a minimum of number of signatures of current House members equaling or exceeding two-thirds the number of all House members currently eligible to vote.
+	\item If the majority of the Executive Board votes are positive, or the negative vote was overridden, the petition is presented at the following House Meeting and the accused and accuser(s) again present their cases.
+	\item Ballots will then be distributed and a secret ballot House vote shall be held for a minimum of a forty-eight hour period to determine whether or not the member should be removed from office.
+		Votes shall be collected and counted as described in \ref{Balloted Vote}.
+	\item A quorum of two-thirds of the Total Number of Possible Votes is necessary for the vote to be official.
+		A vote equaling or exceeding two-thirds the number of all ballots cast is necessary for the accused officer to be removed from office.
+		If a quorum cannot be reached after two attempts, or the percentage of affirmative votes does not equal or exceed the minimum, impeachment proceedings are dismissed.
+	\item If the percentage of affirmative votes equals or exceeds the minimum the impeached officer is relinquished of their position and any benefits thereof and this position is treated like any other vacated position.
+		A new selection and interim duty fulfillment procedure is followed similar to that of a resignation; see \ref{Executive Board Resignations}.
+	\item House Secretary can be impeached according to the above process, or may be dismissed by a Simple Majority vote of the Executive Board.
+\end{enumerate}
+
+\asubsection{Term}
+\begin{enumerate}
+\item The Election Process for the following year's Executive Board members shall begin in the middle of Spring semester.
+\item The newly selected officers shall begin their terms on June 1 of that year and their terms shall end on May 31 of the following year.
+\item The term of an officer will be abbreviated due to resignation, impeachment, or change in membership status.
+\item Officers elected or selected during the course of the year due to an abbreviated term of the previous officer shall hold office until the end of the normal term.
+\item When the task of an Ad Hoc Directorship has been completed, the directorship dissolves.
+	When an Ad Hoc Director resigns, the directorship dissolves and must be reinstated with a new director.
+\end{enumerate}
+
+\asubsection{Appeals}
+Decisions made by the Executive Board may be appealed and overturned.
+To initiate an appeal, a member must have the support of three voting members of the Executive Board, or a petition with the signatures of one-third of Active Members.
+After the appeal is presented, a Simple Majority vote is held by the Executive Board whether or not to overturn and reevaluate the decision.
+If the vote passes, the Executive Board may discuss and make a new ruling by another Simple Majority vote.
+
+\asection{Maintainers}
+
+\asubsection{Maintainer Qualifications}
+Maintainers must be Active or Alumni Members.
+
+\asubsection{Maintainer Expectations}
+Maintainers are expected to:
 \begin{itemize}
-\item Attend all House meetings during the process
-\item Complete the Introductory Packet
-\item Attend at least one House directorship meeting for each week of the process (including permanent and Ad Hoc directorship meetings)
-\item Attend at least one House social event during the process
-\item Attend at least two seminars relating to computing or electronics
-\item Sign a copy of the Membership Agreement describing a House Member’s responsibilities and expectations
+	\item Be knowledgeable about the Constitution
+	\item Review changes to the Constitution for grammar, spelling, and internal consistency
+	\item Participate in discussion of proposals and amendments
+	\item Keep a public record of changes to the Constitution
 \end{itemize}
+Failure to meet any of these expectations is grounds for revocation of Maintainer status by the Executive Board.
 
-\asubsubsubsection{Introductory Evaluation}
-The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of Active Membership.
-It occurs at the conclusion of the final week of the Process.
+\asubsection{Maintainer Term}
+Maintainer status lasts until it is resigned, or until it is revoked by Executive Board vote.
+A Maintainer may resign at any time by notifying the current Executive Board and Maintainer group.
+If a Maintainer no longer satisfies \ref{Maintainer Qualifications}, they lose Maintainer status.
 
-\asubsubsubsubsection{Voting}
-On a member by member basis, this evaluation process determines if each Introductory member has successfully completed the Introductory Process requirements \ref{Expectations of an Introductory Member}.
-A Simple Majority vote with a quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.
-In order for an Active Member to be counted as a Possible Vote they must meet the requirements outlined in \ref{Expectations of Voting Members}.
-Neither absentee nor proxy votes are allowed.
-House may choose any of the Outcomes for each member.
-\asubsubsubsubsection{Expectations of Voting Members}
-The following requirements must be met by the beginning of the Introductory Evaluation for an Active Member to be allowed to vote. 
-Any of these requirements may be waived by the Evaluations Director or a simple majority vote by the Executive Board
-\begin{itemize}
-\item Attend all House meetings during the process
-\item Attend at least one House directorship meeting for each week of the process (including permanent and Ad Hoc directorship meetings)
-\item Attend at least one House social event during the process
-\item Attend at least two seminars relating to computing or electronics
-\end{itemize}
+\asubsection{Maintainer Selection}
+Any member may nominate a qualified member for Maintainer status to the Executive Board for consideration.
+The Executive Board may choose to approve or reject the nomination by Simple Majority vote with a quorum of seventy-five percent of the Total Number of Possible Votes.
 
-\asubsubsubsubsection{Outcomes}
-\renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
-\begin{enumerate}
-	\item Introductory Members may be offered Active Membership (\ref{Active Membership}) provided they meet the requirements described in \ref{Expectations of an Introductory Member}, at the discretion of House.
-	\item If an Introductory Member fails to meet the requirements, their membership will be revoked.
-	\item An Introductory member may be given a conditional to complete as a means of making up for missing requirements.
-		A conditional may be proposed by any member present at the Introductory Evaluation and, if it is approved by the Evaluations Director, is then voted on by House.
-		Each conditional consists of a set of additional requirements and a deadline for completing them.
-		When the deadline expires, the conditional will be brought before the Executive Board who will assess its completeness.
-		A conditional member who does not meet these additional requirements forfeits membership.
-\end{enumerate}
-\asubsubsection{Selection Processes}
-\renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
-
-% Current RIT students is defined as students who have attended RIT for at least 1 full semester
-\asubsubsubsection{Selection Process for Current RIT Students}
-\begin{enumerate}
-	\item The applicant submits an application to the Evaluations Director for review.
-	\item The applicant participates in an informal interview with exactly three current Active, Alumni, or Honorary Members.
-	\item The application materials are then reviewed at an Evaluations meeting.
-	Then a simple majority vote, of attending members, is held on whether or not to accept the person as an Introductory Member.
-\end{enumerate}
-Note: Most membership privileges do not initiate until successful completion of the introductory process.
-This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
-The member does, however, have the right to use Computer Science House's facilities.
-The member is not required to pay dues during the Introductory Process.
-\\* \\*
-Additional Note: No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
-
-% Incoming RIT students is defined as students who have attended RIT for less than 1 full semester
-\asubsubsubsection{Selection Process for Incoming RIT Students}
-\begin{enumerate}
-	\item During Spring semester, the Evaluations Director selects a group of Active Members to form a Selections Committee.
-		The Selections Committee reviews applications and conducts interviews in accordance with the process prescribed by Residence Life.
-        \item A subset of applicants will be offered Introductory Membership and must participate in the Introductory Process defined in \ref{The Introductory Process}. 
-            A subset of Introductory Members will be offered On-Floor status and will be able to select a room on floor. 
-            The other Introductory Members will have Off-Floor status, but will otherwise have the same privileges and responsibilities.
-\end{enumerate}
-Note: Most membership privileges do not initiate until successful completion of the introductory process.
-This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
-The member does, however, have the right to use Computer Science House's facilities.
-The member is not required to pay dues during the Introductory Process.
-\\* \\*
-Additional Note: No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
-\asubsubsubsection{Selection Process for Honorary Members}
-\begin{enumerate}
-	\item A House Member submits to the Evaluations Director a nomination for a person they feel is deserving of Honorary Membership.
-	\item The Evaluations Director performs some preliminary research on the candidate and presents the findings.
-	\item The Executive Board decides whether or not to present the nomination to the House for a secret ballot House vote.
-		If the Executive Board decides not to present the nomination to the House, the Selection Process ends and the candidate does not become an Honorary Member.
-	\item The nomination is presented at a House Meeting for discussion and a Two-Thirds vote, as described in \ref{Two-Thirds}.
-		Ballots are distributed and voting must remain open for a minimum of forty-eight hour period.
-	\item The candidate is notified of their selection as an Honorary Member and presented with the honor.
-\end{enumerate}
-\asubsubsubsection{Selection Process for Advisory Members}
-\begin{enumerate}
-	\item When there is a perceived need, the Executive Board may open nominations for Advisory Members.
-		After an announcement at House Meeting, during a 72-hour period, any House Member may submit a nomination.
-	\item After the close of the nomination collection period, the Executive Board will arrange some means for the House to meet with the nominees.
-	\item A discussion of the candidates will be held at the following House meeting.
-	\item Ballots are distributed for each nominee as a fifty-percent House vote defined in \ref{Fifty Percent}.
-		Voting must remain open for a minimum of a forty-eight hour period.
-	\item All candidates selected are notified of their acceptance as House Advisors and asked to accept or decline the selection.
-\end{enumerate}
-
-\asubsubsection{Evaluations Processes}
-During the academic year, a House member is evaluated by the Membership Evaluation.
-The Membership Evaluation is responsible for determining those individuals who will have the option to continue Active Membership in the following year.
-Semi-Annual Evaluations Meetings are open only to current Active Members.
-All Executive Board members are expected to attend the Semi-Annual Evaluations Meetings to assist in the evaluations of House members.
-\\* \\*
-At the beginning of any Evaluation Process listed herein, the Evaluations Director must read the sections of the Computer Science House Constitution used during the respective Evaluation Process.
-It is incumbent upon each House member to provide the Evaluation Director with whatever information they feel is necessary to ensure an accurate evaluation.
-\asubsubsubsection{Membership Evaluation}
-The Membership Evaluation process occurs once per academic year.
-It is performed as part of the Evaluation Process that takes place during the spring semester to comply with RIT Housing deadlines.
-\asubsubsubsubsection{Voting}
-Any Active Member who has completed all of the requirements as defined in \ref{Expectations of House Members} at the beginning of the Membership Evaluation passes their Membership Evaluation without being voted on or evaluated by the quorum.
-All Active Members who have not recieved an exemption from the Executive Board prior to the Membership Evaluation will be evaluated on a Member by Member basis by a quorum of Active Members.
-The Membership Evaluation shall hold members to the objective requirements defined in \ref{Expectations of House Members} and determine which members may continue as an Active Member in the following Standard Operating Session.
-Exceptions to the requirements may be made, as House may choose any of the Outcomes for each Member, even if the Member being evaluated has not completed all of their requirements.
-These requirements must be completed before the Membership Evaluation occurs.
-A Secret Immediate Simple Majority vote with a Quorum of two-thirds of the Total Number of Possible Votes is required for the evaluation to be valid.
-Neither absentee nor proxy votes are allowed.
-
-
-\asubsubsubsubsection{Outcomes}
-Members who pass Membership Evaluation have the option to participate as an Active Member in the following year and remain on the upcoming roster if applicable.
-\\* \\*
-If a member fails and has never passed a Membership Evaluation in the past, their membership will be revoked immediately.
-If the member has previously passed a Membership Evaluation they will move to Alumni Membership status at the end of the Standard Operating Session (\ref{Alumni Membership Selection}).
-In either case, the member forfeits their ability to be included on the following year’s roster.
-\\* \\*
-A member may be given a conditional to complete as a means of making up for missing requirements.
-A conditional may be proposed by any member present at the Evaluation.
-If the conditional is approved by the Evaluations Director, it is then voted on by House.
-Each conditional consists of a set of additional requirements a deadline for completing them.
-When the deadline expires, the conditional will be brought before the Executive Board who will assess its completeness.
-A conditional member who does not meet these additional requirements will have failed the evaluation.
-\asubsubsubsection{Appeals Process}
-If a member disagrees with the outcome of any evaluation, (e.g. is not asked to return to the House for the following year) and wishes to appeal the decision, they may do so as stated in \ref{Appeals}.
-\\* \\*
-If the member is still unsatisfied after being heard by the Executive Board, the appeal may be brought to the attention of the ResLife Advisor.
-
-\asubsubsection{Expectations of House Members}
-Each member is required to pay House dues as stated in \ref{Collection of House Dues}, attend all House Meetings and Executive Board candidate speeches, and attend at least fifteen (15) of the House directorship meetings (including permanent and Ad Hoc directorship meetings) for each Academic Semester in which they are an Active Member.
-\\* \\*
-The member must participate significantly in at least one major project during the academic year.
-The member is required to submit a description for this major project to the Executive Board for approval.
-As an option to this requirement, the member may instead assist on a large number of House activities and projects.
-However, it is to be understood in advance by the member that this option requires a great deal of participation throughout the year.
-This participation will be evaluated by the Executive Board.
-
-\asubsubsection{Housing Status}
-All Alumni, Active, and Introductory Members have a housing status.
-This status indicates their right to priority housing on the floor.
-Alumni Members in good standing keep the housing status they had as Active Members.
-Alumni Members in bad standing have Off-Floor status.
-\asubsubsubsection{On-Floor Status}
-Members with On-Floor status are eligible to live on the floor.
-To be granted On-Floor status, members may notify the Evaluations Director that they would like to come up for a vote.
-The Evaluations Director will then bring them up for vote at the next meeting.
-\asubsubsubsection{Off-Floor Status}
-Members with Off-Floor status do not have the right to live on the floor.
-They still have access to all other privileges associated with their membership, and may still accumulate Housing Priority Points.
-
-\asubsubsection{Housing Priority System}
-The Housing Priority System is a means for determining the priority a House member has in a Housing issue such as Single Room Assignment or the Assignment of Available Housing.
-The member with top priority is the member with on-floor status and the most Housing Priority Points.
-Housing Priority Points are accumulated once per Operating Session at the conclusion of the Membership Evaluation. Each Active Member who passes the Membership Evaluation is granted two (2) Housing Priority Points.
-\\* \\*
-In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
-\asubsubsubsection{Single Room Assignments}
-When a single room on the House becomes available it is offered to the member who carries the highest Housing Priority as defined in \ref{Housing Priority System}.
-In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
-If that House member declines the option, it will be offered to the member with the next highest Housing Priority.
-This process continues until a member selects to move into the single room.
-Once in a single room, a House member retains the assignment until voluntarily giving it up.
-It should be noted that members selecting this option must agree to any additional charges applied by the Department of Residence Life for residing in a single room.
-\asubsubsubsection{Double Rooms as Single rooms}
-During the third week of each semester, if there is no waiting list for residency on the House, any vacant rooms will be offered to House members as single rooms assignments according to the method as described in \ref{Single Room Assignments}.
-It should be noted that this does not mean members will be relocated into empty spaces so that the member with top priority is offered the single.
-This only applies if there is a totally vacant room.
-
-\asubsection{Operations of the Operational Communications Directorship}
+\asection{Root Type Persons}
 The Operational Communications Directorship is responsible for overseeing the implementation of maintenance and upgrades to the House Computer Systems Network.
 It is a self-governing committee making decisions by a simple majority vote.
 Membership is composed of all Root Type Persons.
 
-\asubsubsection{Selection of a Root Type Person}
+\asubsection{Selection of a Root Type Person}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \begin{enumerate}
 	\item Nominations are taken from the Root Type Persons and Prior Root Type Persons meeting the selection criteria in \ref{Qualifications of a Root Type Person}.
@@ -727,150 +736,112 @@ The following process is used for making changes to the Code of Conduct document
 	\item The final proposal is presented at the next House Meeting and ballots are distributed for a Balloted House vote as described in \ref{Balloted Vote}.
 \end{enumerate}
 
+% ARTICLE III - GENERAL OPERATIONS OF THE HOUSE
+\article{General Operations of the House}
 
-\asection{Qualifications}
-\asubsection{Qualifications to be the Chairperson, Evaluations Director}
-\begin{enumerate}
-	\item Candidates must be Active Members during the term of office
-	\item Candidates must reside on floor during the term of office
-	\item Candidates must have at least one full semester of House membership as an Active Member
-	\item Elected or selected candidates may not hold a simultaneous voting Executive Board position, and must therefore resign their current position, or the position of Chairperson, should they be elected
-\end{enumerate}
-\asubsection{Qualifications to be the Social Director(s), Financial Director, Research and Development Director(s), House Improvements Director, House History Director, Public Relations Director}
-\begin{enumerate}
-	\item Candidates must be Active Members during the term of office
-	\item Candidates must have at least one full semester of House membership as an Active Member
-	\item Elected or selected candidates may not hold two simultaneous voting Executive Board positions, and must therefore resign their current position or decline a second position should they be elected or selected to a second voting position
-\end{enumerate}
-\asubsection{Qualifications to be the Operational Communications Director}
-\begin{enumerate}
-	\item Candidates must be a current Root Type Person \ref{Operations of the Operational Communications Directorship}.
-	\item Candidates must be a current Active Member.
-	\item A Root Type Person cannot be the director if they currently hold any other voting Executive Board Position.
-\end{enumerate}
+% BY-LAW IV - OPERATIONS OF THE EVALUATIONS DIRECTORSHIP
+\asection{Financial Operations of the House}
+\asubsection{Amount of House Dues}
+The amount of dues for Active Members will be eighty dollars (\$80.00) per Academic Semester.
+\asubsection{Collection of House Dues}
+The collection period of house dues will be decided in conjunction with The Center for Residence Life and Housing Operations.
+During the dues collection period, dues for on-floor members (for both semesters) are collected through the member’s RIT bill.
+Dues for off-floor members are to be collected during this period as well by the Financial Director.
+For any member who moves on or off-floor during the year, any difference between dues paid and dues owed should be collected.
+Dues for any alumnus/alumnae in good standing are to be collected when intention to pay is expressed to the Financial Director.
+\asubsubsection{Rules for Giving Exceptions and Exemptions for House Dues}
+If a member is unable to pay dues upon request, they may appeal their situation to the Financial Director.
+If the Financial Director deems their situation appropriate, they may grant specific extensions or reductions of the member's payment as they see fit.
+If the Financial Director deems their situation inappropriate for extension, the member may appeal to the Executive Board.
+If the Executive Board disagrees with the Financial Director, the Executive Board may reduce the required payment or extend the payment deadline.
+If the Executive Board agrees with the Financial director, the member’s payment is considered delinquent and the member’s privileges are revoked until payment can be made.
+In the case the Financial Director or Executive Board decides the situation is appropriate, the member's dues may be partially or fully excused, or the member may be given additional time to pay their dues. 
+Additional time and reduction of dues may both be given to a member in an appropriate situation.
+All dues must be collected in full before the annual membership evaluation (\ref{Membership Evaluation}).
+After this date, dues collection is suspended until the start of the next academic year.
+\asubsection{Breakdown of Dues for Directorship Budgets}
+\begin{center}
+\begin{tabular}[c]{|l c|}
+\hline
+Directorship Name & Percentage of Dues \\
+\hline
+\hline
+Operational Communications & 20\% \\
+\hline
+Evaluations & 5\% \\
+\hline
+House History & 10\% \\
+\hline
+House Improvements & 15\% \\
+\hline
+Research and Development & 20\% \\
+\hline
+Social & 20\% \\
+\hline
+Public Relations & 5\% \\
+\hline
+Accumulated & 5\% \\
+\hline
+\end{tabular}
+\end{center}
 
-\asubsection{Qualifications to be the House Secretary or an Ad Hoc Director}
-\begin{enumerate}
-\item Candidates must be Active Members
-\end{enumerate}
+% The suggested total operating budget is $8360.
+% This figure comes from having approximately 55 on-floor members with $80 per semester dues (totaling $8800) minus 5% set aside for Accumulated.
 
-\asubsection{Waiving of Qualifications}
-\begin{enumerate}
-  \item House may choose to waive the following subset of the Qualifications for Executive Board positions (defined under \ref{Qualifications}) for all Candidates:
-    \begin{enumerate}
-      \item Candidates must reside on floor during the term of office.
-      \item Candidates must have at least one full semester of House membership as an Active Member.
-      \item Social and Research and Development are the only voting Executive Board positions that allow for Dual Directorship.
-    \end{enumerate}
-  \item When a waiver is proposed, the Chair of the Vote shall state which Executive Board position and Qualification is being voted upon, and any nominated Candidates not qualified under \ref{Qualifications} who would become qualified if the waiver passes.
-  \item A Three-Quarters Immediate Vote, as defined in \ref{Three-Quarters} and \ref{Immediate Vote}, is then taken to determine whether the proposed waiver shall take effect.
-  \item Each vote to waive a Qualification must only apply to a single Qualification for a single Executive Board position.
-  \item Waivers always apply to all Candidates for the Executive Board position.
-\end{enumerate}
+Dues collected from on-floor members are to be distributed into directorship budgets as shown in the above table.
+Money allocated for Accumulated or collected from off-floor members is deposited into the CSH Account and saved.
 
-\asection{Selection}
-\asubsection{Dual Directorship}
-Social and Research and Development are the only voting Executive Board positions that allow for Dual Directorship.
-If two candidates elect to run as a Dual Directorship, their names are placed together on a single line of the election ballot.
-If they are also nominated as a normal directorship or as a dual directorship with another House member, their votes are not cumulative.
-Each different nomination must be a separate entry on the election ballot.
-Non-voting Executive Board positions (i.e. Ad Hoc Directors) are not restricted to single or dual directorship.
+\asubsection{Expenditure Approval}
+All House expenditures must be approved by both the Financial Director and the appropriate Director (from whose budget the funds will be drawn).
+Single expenditures may not exceed seventy-five dollars (\$75) and total expenditures may not exceed one-hundred dollars (\$100).
+A total expenditure is defined as all the funds drawn for a specific event, project, piece of equipment, or service.
+\\* \\*
+If the above amounts are to be exceeded, the expenditure must be approved by a Simple Majority vote at House meeting before the funds may be appropriated, as defined in \ref{Simple Majority}.
+At the Financial Director's discretion, a Spending Committee meeting may be held in order to approve any purchase exceeding one-hundred dollars (\$100), but not to exceed three-hundred dollars (\$300).
+A quorum of one-quarter the number of current active members is required for the meeting to take place and for any vote to be considered valid, it must be passed by a simple two-thirds majority.
+\\*\\*
+For expenditures exceeding \$300 in total funding, a Complete Project Proposal must be presented to House at a House meeting.
+This proposal includes the project budget, inventory of required resources, and a timeline for completion.
+\\* \\*
+If an appropriate Directorship cannot be determined for an expenditure, it is to be brought up for approval at House meeting as a Miscellaneous expenditure and approved by a simple majority vote, regardless of the amount.
+This amount is to be directly subtracted from the general CSH account.
+\\* \\*
+Funds allocated for a project not spent by the end of the Standard Operating Session \ref{Standard Operating Session} in which they were approved are voided, unless otherwise specified during the original voting process.
 
-The following special cases cover the operation of a dual directorship:
-\begin{itemize}
-	\item If one of the members in a dual directorship resigns the directorship, or for any other reason ends the term of office, the other member in the dual directorship must also step down and the office becomes vacated.
-		The vacated office is then handled like any other vacated office; see \ref{Executive Board Resignations}.
-	\item During an official Executive Board Vote, each dual directorship member's vote counts for one-half vote in the tallying of votes.
-		The members of the dual directorship need not vote the same way in a vote.
-	\item A member of a dual directorship may not hold any other Executive Board position.
-	\item When attendance requirements call for the dual directorship position to be present, both dual directorship members are to fulfill the requirements.
-\end{itemize}
-\asubsection{Selection of the Chairperson, Evaluations Director, Social Director(s), Financial Director, House Improvements Director, House History Director, Research and Development Director(s), Public Relations Director}
-\begin{enumerate}
-	\item The opening of the Executive Board position(s) is announced at a House meeting and nominations for the position are taken for a minimum of a seventy-two hour period.
-		Any House member may nominate any member or pair of members where appropriate for a Directorship.
-	\item The candidates will be notified of their nomination.
-		Each candidate is given a minimum of twenty-four hour period to accept or decline the nomination.
-		A list of all nominees who have accepted their nominations will be posted shortly thereafter.
-	\item The date and time of candidate speeches will be announced by a member of the Executive Board at least five (5) days prior to the event. 
-		All Active Members are expected to attend candidate speeches in accordance with \ref{Expectations of House Members}.
-		If a member cannot attend due to a scheduling conflict, they may provide a reason for their absence to the Evaluations Director, who will record the reason with the absence.
-	\item Each candidate will be given an equal amount of time before the House to present their platform of candidacy.
-	\item Ballots will then be distributed and voting will be open for a minimum of a forty-eight hour period.
-		The Ballots will list, in random order, all of the candidates who are qualified for a given office with a means to indicate the selection of one of the candidates.
-		In addition, an area will be provided to indicate a write-in selection of a candidate.
-	\item At the end of the voting period, the Chairperson will terminate voting by collecting the ballot box and the votes shall be counted as stated in \ref{Alternative Vote}.
-	\item The winners are determined via the process described in \ref{Alternative Vote}.
-		A quorum of fifty-percent of the number of all members eligible to vote is required for the election to be official.
-		All winners are notified of their election.
-		If the position is currently vacant, the winner immediately assumes office.
-		If not, the winner will assume office at the end of the current term (\ref{Term}).
-		Any office whose winner declines the election, or whose winner does not fulfill the requirements of the elected office, shall have their votes redistributed in the same process as a loser in \ref{Alternative Vote}.
-\end{enumerate}
-\asubsection{Selection of the Operational Communications Director}
-\begin{enumerate}
-	\item A candidate for the Operational Communications Directorship shall be chosen by the current Root Type Persons.
-	\item The candidate is given a minimum of twenty-four hours to accept or decline the nomination.
-	\item The candidate is presented to the Executive Board for approval.
-		This Executive Board meeting is closed to the Executive Board Members, Root Type Persons, and House members with explicit invitation from the Executive Board.
-	\item All current Executive Board Voting Members must be present during the discussion and voting period unless that member is a candidate for the position, in which case the member is absent and their vote is abstained.
-		A simple majority Executive Board vote, as described in \ref{Simple Majority}, is taken to determine whether the candidate is selected for the position.
-\end{enumerate}
-\asubsection{Selection of Ad Hoc Directors}
-\begin{enumerate}
-	\item When the Executive Board or a group of House members feels an Ad Hoc Directorship is necessary, they present their plans to the Executive Board and the Executive Board decides by simple majority vote whether directorship status is granted.
-	\item When the Ad Hoc Directorship is granted status, a director is appointed, and duties, budgetary, and membership considerations are defined.
-\end{enumerate}
-\asubsection{Selection of the House Secretary}
-The Executive Board may choose to select a current voting Executive Board member, or to select any interested Active member, as House Secretary.
-The selection process can be an informal appointment, or follow an election process similar to other voting Executive Board positions.
+% HOUSING
+\asection{Housing}
 
-\asection{Executive Board Resignations}
-An Executive Board Member may resign their position by submitting in writing the reason for resignation to the House Chairperson.
-The resignation will be read at the following House Meeting and become effective at that time.
-The office will become vacant and the selection process for a new member as described in section \ref{Appointment of an Interim Director} will begin at that time.
-Following a resignation, the Selection process, as defined in \ref{Selection}, of a replacement for the position vacated must begin within two weeks from when the resignation took place.
-To postpone such a Selection, the Chairperson may chair an Immediate Simple Majority Vote \ref{Immediate Vote} \ref{Simple Majority} during a House Meeting prior to the beginning of the Selection process to delay the Selection process by a specified amount of time.
+\asubsection{Housing Status}
+All Alumni, Active, and Introductory Members have a housing status.
+This status indicates their right to priority housing on the floor.
+Alumni Members in good standing keep the housing status they had as Active Members.
+Alumni Members in bad standing have Off-Floor status.
+\asubsubsection{On-Floor Status}
+Members with On-Floor status are eligible to live on the floor.
+To be granted On-Floor status, members may notify the Evaluations Director that they would like to come up for a vote.
+The Evaluations Director will then bring them up for vote at the next meeting.
+\asubsubsection{Off-Floor Status}
+Members with Off-Floor status do not have the right to live on the floor.
+They still have access to all other privileges associated with their membership, and may still accumulate Housing Priority Points.
 
-\asection{Appointment of an Interim Director}
-The duties and responsibilities of a vacated office are assumed by the Chairperson or by an Active member that is appointed at the Chairperson's discretion until the new member takes office.
-The vote of a vacated Executive Board position shall be cast as an abstention in all Executive Board matters where this vote is required to be cast.
+\asubsection{Housing Priority System}
+The Housing Priority System is a means for determining the priority a House member has in a Housing issue such as Single Room Assignment or the Assignment of Available Housing.
+The member with top priority is the member with on-floor status and the most Housing Priority Points.
+Housing Priority Points are accumulated once per Operating Session at the conclusion of the Membership Evaluation. Each Active Member who passes the Membership Evaluation is granted two (2) Housing Priority Points.
+\\* \\*
+In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
+\asubsubsection{Single Room Assignments}
+When a single room on the House becomes available it is offered to the member who carries the highest Housing Priority as defined in \ref{Housing Priority System}.
+In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
+If that House member declines the option, it will be offered to the member with the next highest Housing Priority.
+This process continues until a member selects to move into the single room.
+Once in a single room, a House member retains the assignment until voluntarily giving it up.
+It should be noted that members selecting this option must agree to any additional charges applied by the Department of Residence Life for residing in a single room.
+\asubsubsection{Double Rooms as Single rooms}
+During the third week of each semester, if there is no waiting list for residency on the House, any vacant rooms will be offered to House members as single rooms assignments according to the method as described in \ref{Single Room Assignments}.
+It should be noted that this does not mean members will be relocated into empty spaces so that the member with top priority is offered the single.
+This only applies if there is a totally vacant room.
 
-\asection{Impeachment}
-\begin{enumerate}
-	\item Impeachment of any Executive Board Member may be initiated by petition, in writing, consisting of a minimum number of signatures of current House members equaling or exceeding one-third the Number of Possible Votes as defined in \ref{Total Number of Possible Votes}.
-	\item The impeachment petition is then presented at an Executive Board Meeting.
-		The member(s) initiating the petition present their case to the Executive Board.
-		The Executive Board then questions the accused member of the allegations.
-	\item The Executive Board votes on the impeachment petition, with all voting members present except the accused member who must be absent and whose vote counts as an abstention, to determine if the allegations stated in the petition are legitimate grounds for impeachment.
-		If the majority of Executive Board votes are negative, the petition and impeachment proceedings are dismissed.
-		This vote may be overridden by an impeachment petition consisting of the grounds for impeachment and a minimum of number of signatures of current House members equaling or exceeding two-thirds the number of all House members currently eligible to vote.
-	\item If the majority of the Executive Board votes are positive, or the negative vote was overridden, the petition is presented at the following House Meeting and the accused and accuser(s) again present their cases.
-	\item Ballots will then be distributed and a secret ballot House vote shall be held for a minimum of a forty-eight hour period to determine whether or not the member should be removed from office.
-		Votes shall be collected and counted as described in \ref{Balloted Vote}.
-	\item A quorum of two-thirds of the Total Number of Possible Votes is necessary for the vote to be official.
-		A vote equaling or exceeding two-thirds the number of all ballots cast is necessary for the accused officer to be removed from office.
-		If a quorum cannot be reached after two attempts, or the percentage of affirmative votes does not equal or exceed the minimum, impeachment proceedings are dismissed.
-	\item If the percentage of affirmative votes equals or exceeds the minimum the impeached officer is relinquished of their position and any benefits thereof and this position is treated like any other vacated position.
-		A new selection and interim duty fulfillment procedure is followed similar to that of a resignation; see \ref{Executive Board Resignations}.
-	\item House Secretary can be impeached according to the above process, or may be dismissed by a Simple Majority vote of the Executive Board.
-\end{enumerate}
-
-\asection{Term}
-\begin{enumerate}
-\item The Election Process for the following year's Executive Board members shall begin in the middle of Spring semester.
-\item The newly selected officers shall begin their terms on June 1 of that year and their terms shall end on May 31 of the following year.
-\item The term of an officer will be abbreviated due to resignation, impeachment, or change in membership status.
-\item Officers elected or selected during the course of the year due to an abbreviated term of the previous officer shall hold office until the end of the normal term.
-\item When the task of an Ad Hoc Directorship has been completed, the directorship dissolves.
-	When an Ad Hoc Director resigns, the directorship dissolves and must be reinstated with a new director.
-\end{enumerate}
-
-\asection{Appeals}
-Decisions made by the Executive Board may be appealed and overturned.
-To initiate an appeal, a member must have the support of three voting members of the Executive Board, or a petition with the signatures of one-third of Active Members.
-After the appeal is presented, a Simple Majority vote is held by the Executive Board whether or not to overturn and reevaluate the decision.
-If the vote passes, the Executive Board may discuss and make a new ruling by another Simple Majority vote.
 
 % ARTICLE VI - VOTING
 \article{Voting}
@@ -981,7 +952,25 @@ The Judicial Board will be responsible for making all necessary inquiries into t
 The Judicial Board may present an official ruling following the Judicial Investigation.
 This ruling may be appealed in the same manner as an Executive Board decision \ref{Appeals}.
 
-% ARTICLE VIII - ADHERENCE TO UNIVERSITY POLICIES
+% Article VIII - MODIFICATIONS TO THE CONSTITUTION
+\asubsection{Non-Semantic Changes}
+There are two methods for non-semantic change to the Constitution.
+A Maintainer may approve any proposed change that does not affect the meaning of the document.
+Alternatively, the change may be presented to the House for discussion followed by an Immediate Vote.
+A quorum of fifty percent of the Total Number of Possible Votes is required for passage.
+
+\asubsection{Semantic Changes}
+Any semantic change to the Constitution requires the change to be proposed in writing for discussion at a House Meeting.
+Any modifications made due to the discussion are added to the written proposal and the modified proposal is posted in the House during the week.
+The final proposal is presented the following week and ballots are distributed for a ballot House vote as described in \ref{Balloted Vote}.
+The ballots are collected for a minimum of a forty-eight hour period.
+A quorum of two-thirds of the Total Number of Possible Votes must cast ballots for the vote to be official.
+A vote equaling or exceeding two-thirds of the number of votes cast is required for the change to be placed into the constitution.
+The Constitution may be overridden by an immediate House vote as described in \ref{Immediate Vote}.
+There must be a quorum of eighty-five percent of the Total Number of Possible Votes for the vote to be official.
+A vote equaling or exceeding ninety percent of the number of votes cast is required for the override to take effect.
+
+% ARTICLE IX - ADHERENCE TO UNIVERSITY POLICIES
 \article{ADHERENCE TO UNIVERSITY POLICIES}
 \asection{Anti-Hazing}
 \asubsection{RIT Hazing Policy (RIT Student Conduct Process; IV. RIT Code of Conduct; 14. Hazing/Failure to Report


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

1 - moving Packet, Introductory Evaluations, Membership Evaluations, and Selection Processes into the Membership section
2 - moving operations of the Evaluations/Financial directorships into "General Operations of the House"
3 - moving maintainers and RTPs under "Officers of the House"