### PR TITLE
Resolve #146 - 7.D Added new clause to require all Judicials to be recorded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.synctex.gz
 *.py
 *.toc
+.vs/VSWorkspaceState.json
+.vs/Constition Repo/v17/.wsuo

--- a/constitution.tex
+++ b/constitution.tex
@@ -729,17 +729,18 @@ The following process is used for making changes to the Code of Conduct document
 
 
 \asection{Qualifications}
-Elected or selected candidates may not hold more then one simultaneous Executive Board positions, and must therefore resign their current position or decline the other position should they be elected or selected to another position.
 \asubsection{Qualifications to be the Chairperson, Evaluations Director}
 \begin{enumerate}
 	\item Candidates must be Active Members during the term of office
 	\item Candidates must reside on floor during the term of office
 	\item Candidates must have at least one full semester of House membership as an Active Member
+	\item Elected or selected candidates may not hold a simultaneous voting Executive Board position, and must therefore resign their current position, or the position of Chairperson, should they be elected
 \end{enumerate}
 \asubsection{Qualifications to be the Social Director(s), Financial Director, Research and Development Director(s), House Improvements Director, House History Director, Public Relations Director}
 \begin{enumerate}
 	\item Candidates must be Active Members during the term of office
 	\item Candidates must have at least one full semester of House membership as an Active Member
+	\item Elected or selected candidates may not hold two simultaneous voting Executive Board positions, and must therefore resign their current position or decline a second position should they be elected or selected to a second voting position
 \end{enumerate}
 \asubsection{Qualifications to be the Operational Communications Director}
 \begin{enumerate}
@@ -979,6 +980,8 @@ The Judicial Board will be responsible for making all necessary inquiries into t
 \asection{Judicial Ruling}
 The Judicial Board may present an official ruling following the Judicial Investigation.
 This ruling may be appealed in the same manner as an Executive Board decision \ref{Appeals}.
+\asection{Judicial Records}
+All Judicials must be recorded in a public document accessible to all Active Members and Alumni by an Executive Board member. Judicial Records must include the context, vote split, and outcome, and optionally the reasoning of why the Executive Board decided on the outcome. Executive Board can choose, through a Simple Majority Vote, to instead move the Judicial Record to a private document accessible only to past, present, and future Executive Board members, but the content requirements do not change.
 
 % ARTICLE VIII - ADHERENCE TO UNIVERSITY POLICIES
 \article{ADHERENCE TO UNIVERSITY POLICIES}

--- a/constitution.tex
+++ b/constitution.tex
@@ -729,18 +729,17 @@ The following process is used for making changes to the Code of Conduct document
 
 
 \asection{Qualifications}
+Elected or selected candidates may not hold more then one simultaneous Executive Board positions, and must therefore resign their current position or decline the other position should they be elected or selected to another position.
 \asubsection{Qualifications to be the Chairperson, Evaluations Director}
 \begin{enumerate}
 	\item Candidates must be Active Members during the term of office
 	\item Candidates must reside on floor during the term of office
 	\item Candidates must have at least one full semester of House membership as an Active Member
-	\item Elected or selected candidates may not hold a simultaneous voting Executive Board position, and must therefore resign their current position, or the position of Chairperson, should they be elected
 \end{enumerate}
 \asubsection{Qualifications to be the Social Director(s), Financial Director, Research and Development Director(s), House Improvements Director, House History Director, Public Relations Director}
 \begin{enumerate}
 	\item Candidates must be Active Members during the term of office
 	\item Candidates must have at least one full semester of House membership as an Active Member
-	\item Elected or selected candidates may not hold two simultaneous voting Executive Board positions, and must therefore resign their current position or decline a second position should they be elected or selected to a second voting position
 \end{enumerate}
 \asubsection{Qualifications to be the Operational Communications Director}
 \begin{enumerate}


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s): Added a new 7.D Judicial Record Clause, that requires all Judicials to record the context, vote split, outcome, and optionally reasoning of Eboard members of all Judicials, and gives Eboard the ability to instead record the Judicial in a private document with a Simple Majority Vote (however, the content requirements are the same). 

