### PR TITLE
Update Open House Responsibilities for Evals and PR

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -371,7 +371,6 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To oversee the Membership Evals of Active Members
 	\item To collaborate with the ResLife Advisor to determine room change selection and any changes of membership residency
 	\item To act as a part of a Judicial Board as defined in \ref{Judicial}
-	\item To prepare the House for Open Houses, tours, and special events
 	\item To vote on issues presented to the Executive Board
 \end{enumerate}
 
@@ -390,6 +389,7 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To oversee the organization, initiation, and execution of House philanthropic events
 	\item To preserve and improve the public image of House
 	\item To collaborate with other E-Board members to organize, initiate, execute, and advertise any events that are intended to be attended by persons whom have never been Active Members
+    \item To oversee the preparation of House for Open Houses, tours, and special events
 	\item To vote on issues presented to E-Board
 \end{enumerate}
 


### PR DESCRIPTION
Check one:
- [X] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
This PR moves the responsibility of overseeing to organization of Open Houses and similar events from Evals to PR.
