### PR TITLE
Removed extra newline that caused document to fail to compile

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -326,7 +326,6 @@ In order to request a Leave of Absence, a member must follow the RIT policy for 
 \article{E-Board}
 The E-Board is the main governing body of the House.
 Its purpose is to provide leadership and direction for the House, to oversee the day-to-day operations of the House, and to initiate and organize programs and projects for the House.
-
 \\*\\*
 There is one permanent directorship for each major aspect of the government of the House and each one is chaired by an E-Board member.
 Ad Hoc directorships are created on an as-needed basis.


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
removed an extra newline before a line break to fix existing compilation errors
