### PR TITLE
Resolves #72 Gives Ad Hocs Their Own Section (Again)

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -710,7 +710,7 @@ Ad Hoc Directors are responsible for the task for which they were created.
 Additionally, any responsibilities, budgets, or finances for the Ad Hoc Directorship are placed upon the assigned director(s).
 Ad Hoc Directorships are not restricted to single or dual directorship rules.
 \asubsubsection{Qualifications of Ad Hoc Director(s)}
-\hfill\break
+\hfill\break\hfill\break
 Candidates must be Active Members.
 
 \asubsection{Selection of Ad Hoc Directors}

--- a/constitution.tex
+++ b/constitution.tex
@@ -708,14 +708,16 @@ Ad Hoc Directorships are created by the Executive Board on an as-needed basis.
 They are generally task-oriented and are chaired by a House member(s).
 Ad Hoc Directors are responsible for the task for which they were created.
 Additionally, any responsibilities, budgets, or finances for the Ad Hoc Directorship are placed upon the assigned director(s).
-Candidates for being Ad Hoc Directors must be Active Members.
-% This is implied, but Ad Hoc Directorships are not intended to be restricted to single or dual directorship rules.
+Ad Hoc Directorships are not restricted to single or dual directorship rules.
+\asubsubsection{Qualifications of Ad Hoc Director(s)}
+\hfill\break
+Candidates must be Active Members.
 
 \asubsection{Selection of Ad Hoc Directors}
 \begin{enumerate}
 	\item When the Executive Board or a group of House members feels an Ad Hoc Directorship is necessary, they present their plans to the Executive Board.
 	An Executive Board Vote is taken to determine whether directorship status is granted.
-	\item When the Ad Hoc Directorship is granted status, a director is appointed, and duties, budgetary, and membership considerations are defined.
+\item When the Ad Hoc Directorship is granted status, a director(s) is appointed. Subsequently the duties, budget, and the membership considerations are defined.
 \end{enumerate}
 
 \asection{Maintainers}

--- a/constitution.tex
+++ b/constitution.tex
@@ -432,8 +432,6 @@ Its purpose is to provide leadership and direction for the House, to oversee the
 \\*\\*
 There is one permanent directorship for each major aspect of the government of the House and each one is chaired by an E-Board member.
 A voting E-Board member is considered to be any person with a non-zero vote on E-Board. % Defined this way so that (for example) each member in a dual directorship is each considered to be a voting member on E-Board.
-Ad Hoc directorships are created on an as-needed basis.
-They are generally very task oriented and are chaired by a House member.
 A directorship has some jurisdiction in its area of interest and often is responsible for the day-to-day decisions regarding its area of interest.
 Any large expenditures or large effect decisions must be brought before the entire House.
 
@@ -557,12 +555,6 @@ Any large expenditures or large effect decisions must be brought before the enti
 	\item To record all votes cast during House Meetings and Open E-Board Meetings
 \end{enumerate}
 
-\asubsubsection{Responsibilities of Ad Hoc Directorships}
-\begin{enumerate}
-	\item Ad Hoc Directorships are responsible for the task for which they were created
-	\item Any responsibilities budgets or finances for the Ad Hoc Directorship are placed upon the assigned director
-\end{enumerate}
-
 \asubsection{Closed Executive Board}
 Closed Executive Board Meetings are open only to the Chairperson, Voting Members of the Executive Board, and those with the express permission of the Executive Board.
 A closed Executive Board meeting may be called at any time by any member of the Executive Board.
@@ -589,7 +581,7 @@ However, the Chairperson and at least two-thirds of the Voting Members of the Ex
 	\item A Root Type Person cannot be the director if they currently hold any other voting Executive Board Position.
 \end{enumerate}
 
-\asubsubsection{Qualifications to be the House Secretary or an Ad Hoc Director}
+\asubsubsection{Qualifications to be the House Secretary}
 \begin{enumerate}
 \item Candidates must be Active Members
 \end{enumerate}
@@ -615,7 +607,6 @@ Social and Research and Development are the only voting Executive Board position
 If two candidates elect to run as a Dual Directorship, their names are placed together on a single line of the election ballot.
 If they are also nominated as a normal directorship or as a dual directorship with another House member, their votes are not cumulative.
 Each different nomination must be a separate entry on the election ballot.
-Non-voting E-Board positions (i.e. Ad Hoc Directors) are not restricted to single or dual directorship.
 
 The following special cases cover the operation of a dual directorship:
 \begin{itemize}
@@ -659,13 +650,6 @@ The following special cases cover the operation of a dual directorship:
 		This Executive Board meeting is closed to the Executive Board Members, Root Type Persons, and House members with explicit invitation from the Executive Board.
 	\item All current Executive Board Voting Members must be present during the discussion and voting period unless that member is a candidate for the position, in which case the member is absent and their vote is abstained.
 		An Executive Board Vote is taken to determine whether the candidate is selected for the position.
-\end{enumerate}
-
-\asubsection{Selection of Ad Hoc Directors}
-\begin{enumerate}
-	\item When the Executive Board or a group of House members feels an Ad Hoc Directorship is necessary, they present their plans to the Executive Board.
-  An Executive Board Vote is taken to determine whether directorship status is granted.
-	\item When the Ad Hoc Directorship is granted status, a director is appointed, and duties, budgetary, and membership considerations are defined.
 \end{enumerate}
 
 \asubsection{Selection of the House Secretary}
@@ -718,6 +702,21 @@ Decisions made by the Executive Board may be appealed and overturned.
 To initiate an appeal, a member must have the support of three voting members of the Executive Board, or a petition with the signatures of one-third of Active Members.
 After the appeal is presented, an Executive Board Vote is taken to determine whether or not to overturn and reevaluate the decision.
 If the vote passes, the Executive Board may discuss and make a new ruling by another Executive Board Vote.
+
+\asection{Ad Hoc Directorships}
+Ad Hoc Directorships are created by the Executive Board on an as-needed basis.
+They are generally task-oriented and are chaired by a House member(s).
+Ad Hoc Directors are responsible for the task for which they were created.
+Additionally, any responsibilities, budgets, or finances for the Ad Hoc Directorship are placed upon the assigned director(s).
+Candidates for being Ad Hoc Directors must be Active Members.
+% This is implied, but Ad Hoc Directorships are not intended to be restricted to single or dual directorship rules.
+
+\asubsection{Selection of Ad Hoc Directors}
+\begin{enumerate}
+	\item When the Executive Board or a group of House members feels an Ad Hoc Directorship is necessary, they present their plans to the Executive Board.
+	An Executive Board Vote is taken to determine whether directorship status is granted.
+	\item When the Ad Hoc Directorship is granted status, a director is appointed, and duties, budgetary, and membership considerations are defined.
+\end{enumerate}
 
 \asection{Maintainers}
 


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Resolves #72 by adding in a section for Ad Hoc Directorships in Article 5 and refactoring some content around it (again).
Check #96 for previous discussion.