### PR TITLE
136 removing dry notes

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -203,6 +203,17 @@ Each Introductory Process participant, after the first week, is given two (2) we
 \end{itemize}
 At the discretion of the Evaluations Director, any Introductory Packet may be extended to accommodate extenuating circumstances.
 \asubsubsection{Expectations of an Introductory Member}
+Before the end of the Process, an Introductor Member is expected to:
+\begin{itemize}
+	\item Attend all House meetings during the process
+	\item Complete the INtroductory Packet
+	\item Attend at least one House Directorship meeting for each week fo the process (including permanent and Ad Hoc directorship meetinsg)
+	\item Attend at least one House social event during the process
+	\item Attend at least two seminars relating to computing of electronics
+	\item Sign a copy of the Membership Agreement describing a House Member's responsibilities and expectations
+\end{itemize}
+
+\asubsubsection{Introductor Evaluation}
 The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of Active Membership.
 It occurs at the conclusion of the final week of the Process.
 
@@ -987,6 +998,9 @@ A vote equaling or exceeding two-thirds of the number of votes cast is required 
 The Constitution may be overridden by an immediate House vote as described in \ref{Immediate Vote}.
 There must be a quorum of eighty-five percent of the Total Number of Possible Votes for the vote to be official.
 A vote equaling or exceeding ninety percent of the number of votes cast is required for the override to take effect.
+
+\asubsection{Semantic Changes}
+Any semantic change to the Constitution requres the change to be proposed in writing for discussion at a House Meeting.
 Any modifications made due to the discussion are added to the written proposal and the modified proposal is posted in the House during the week.
 The final proposal is presented the following week and ballots are distributed for a ballot House vote as described in \ref{Balloted Vote}.
 The ballots are collected for a minimum of a forty-eight hour period.

--- a/constitution.tex
+++ b/constitution.tex
@@ -149,13 +149,12 @@ They must then undergo the selection process as defined in \ref{Selection Proces
 
 \asubsubsection{Selection Processes}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
-\hfill\break
-\hfill\break
+\hfill\break\hfill\break
 Most membership privileges do not initiate until successful completion of the introductory process. 
 This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum. 
 The member does, however, have the right to use Computer Science House's facilities.
 The member is not required to pay dues during the Introductory Process.
-
+\\*\\*
 No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
 
 % Incoming RIT students is defined as students who have attended RIT for less than 1 full semester
@@ -177,12 +176,7 @@ No hazing shall occur at any time during the Selection Process in accordance wit
             A subset of Introductory Members will be offered On-Floor status and will be able to select a room on floor. 
             The other Introductory Members will have Off-Floor status, but will otherwise have the same privileges and responsibilities.
 \end{enumerate}
-Note: Most membership privileges do not initiate until successful completion of the introductory process.
-This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
-The member does, however, have the right to use Computer Science House's facilities.
-The member is not required to pay dues during the Introductory Process.
-\\* \\*
-Additional Note: No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
+
 
 \asubsection{Introductory Membership Expectations}
 Intro members are expected to meet all the requirements of the Intro Process, as described in \ref{Expectations of an Introductory Member}.
@@ -192,7 +186,6 @@ Intro members receive the right to use Computer Science House facilities, to att
 
 \asubsection{Introductory Membership Evaluations}
 \asubsection{The Introductory Process}
-\break
 The Introductory Process is designed to provide an easy means for Introductory Members to meet existing House members, learn House history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
 \asubsection{The Evaluation Period}
 The Process will occur either once or twice per semester, and will last for six (6) weeks.

--- a/constitution.tex
+++ b/constitution.tex
@@ -146,15 +146,14 @@ Intro Membership is open to all RIT students.
 Applicants notify the House of their interest in membership by submitting an application to the Evals Director.
 They must then undergo the selection process as defined in \ref{Selection Processes}.
 
-
 \asubsubsection{Selection Processes}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
 \hfill\break\hfill\break
-Most membership privileges do not initiate until successful completion of the introductory process. 
-This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum. 
+Most membership privileges do not initiate until successful completion of the introductory process.
+This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
 The member does, however, have the right to use Computer Science House's facilities.
 The member is not required to pay dues during the Introductory Process.
-\\*\\*
+\\* \\*
 No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
 
 % Incoming RIT students is defined as students who have attended RIT for less than 1 full semester
@@ -167,7 +166,6 @@ No hazing shall occur at any time during the Selection Process in accordance wit
 	\item The application materials are then reviewed at an Evaluations meeting.
 	Then a simple majority vote, of attending members, is held on whether or not to accept the person as an Introductory Member.
 \end{enumerate}
-
 \asubsubsubsection{Selection Process for Incoming RIT Students}
 \begin{enumerate}
 	\item During Spring semester, the Evaluations Director selects a group of Active Members to form a Selections Committee.
@@ -176,7 +174,6 @@ No hazing shall occur at any time during the Selection Process in accordance wit
             A subset of Introductory Members will be offered On-Floor status and will be able to select a room on floor. 
             The other Introductory Members will have Off-Floor status, but will otherwise have the same privileges and responsibilities.
 \end{enumerate}
-
 
 \asubsection{Introductory Membership Expectations}
 Intro members are expected to meet all the requirements of the Intro Process, as described in \ref{Expectations of an Introductory Member}.
@@ -203,14 +200,14 @@ Each Introductory Process participant, after the first week, is given two (2) we
 \end{itemize}
 At the discretion of the Evaluations Director, any Introductory Packet may be extended to accommodate extenuating circumstances.
 \asubsubsection{Expectations of an Introductory Member}
-Before the end of the Process, an Introductor Member is expected to:
+Before the end of the Process, an Introductory Member is expected to:
 \begin{itemize}
-	\item Attend all House meetings during the process
-	\item Complete the Introductory Packet
-	\item Attend at least one House directorship meeting for each week fo the process (including permanent and Ad Hoc directorship meetings)
-	\item Attend at least one House social event during the process
-	\item Attend at least two seminars relating to computing of electronics
-	\item Sign a copy of the Membership Agreement describing a House Member's responsibilities and expectations
+\item Attend all House meetings during the process
+\item Complete the Introductory Packet
+\item Attend at least one House directorship meeting for each week of the process (including permanent and Ad Hoc directorship meetings)
+\item Attend at least one House social event during the process
+\item Attend at least two seminars relating to computing or electronics
+\item Sign a copy of the Membership Agreement describing a House Member’s responsibilities and expectations
 \end{itemize}
 
 \asubsubsection{Introductory Evaluation}
@@ -990,24 +987,10 @@ This ruling may be appealed in the same manner as an E-Board decision \ref{Appea
 There are two methods for non-semantic change to the Constitution.
 A Maintainer may approve any proposed change that does not affect the meaning of the document.
 Alternatively, the change may be presented to the House for discussion followed by an Immediate Vote.
-Any modifications made due to the discussion are added to the written proposal and the modified proposal is posted in the House during the week.
-The final proposal is presented the following week and ballots are distributed for a ballot House vote as described in \ref{Balloted Vote}.
-The ballots are collected for a minimum of a forty-eight hour period.
-A quorum of two-thirds of the Total Number of Possible Votes must cast ballots for the vote to be official.
-A vote equaling or exceeding two-thirds of the number of votes cast is required for the change to be placed into the constitution.
-The Constitution may be overridden by an immediate House vote as described in \ref{Immediate Vote}.
-There must be a quorum of eighty-five percent of the Total Number of Possible Votes for the vote to be official.
-A vote equaling or exceeding ninety percent of the number of votes cast is required for the override to take effect.
+A quorum of fifty percent of the Total Number of Possible Votes is required for passage.
 
 \asubsection{Semantic Changes}
-Any semantic change to the Constitution requres the change to be proposed in writing for discussion at a House Meeting.
-Any modifications made due to the discussion are added to the written proposal and the modified proposal is posted in the House during the week.
-The final proposal is presented the following week and ballots are distributed for a ballot House vote as described in \ref{Balloted Vote}.
-The ballots are collected for a minimum of a forty-eight hour period.
-A quorum of two-thirds of the Total Number of Possible Votes must cast ballots for the vote to be official.
-A vote equaling or exceeding two-thirds of the number of votes cast is required for the change to be placed into the constitution.
-The Constitution may be overridden by an immediate House vote as described in \ref{Immediate Vote}.
-There must be a quorum of eighty-five percent of the Total Number of Possible Votes for the vote to be official.
+Any semantic change to the Constitution requires the change to be proposed in writing for discussion at a House Meeting.
 Any modifications made due to the discussion are added to the written proposal and the modified proposal is posted in the House during the week.
 The final proposal is presented the following week and ballots are distributed for a ballot House vote as described in \ref{Balloted Vote}.
 The ballots are collected for a minimum of a forty-eight hour period.

--- a/constitution.tex
+++ b/constitution.tex
@@ -146,8 +146,19 @@ Intro Membership is open to all RIT students.
 Applicants notify the House of their interest in membership by submitting an application to the Evals Director.
 They must then undergo the selection process as defined in \ref{Selection Processes}.
 
+
 \asubsubsection{Selection Processes}
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
+\hfill\break
+\hfill\break
+Most membership privileges do not initiate until successful completion of the introductory process. 
+This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum. 
+The member does, however, have the right to use Computer Science House's facilities.
+The member is not required to pay dues during the Introductory Process.
+
+No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
+
+% Incoming RIT students is defined as students who have attended RIT for less than 1 full semester
 
 % Current RIT students is defined as students who have attended RIT for at least 1 full semester
 \asubsubsubsection{Selection Process for Current RIT Students}
@@ -157,14 +168,7 @@ They must then undergo the selection process as defined in \ref{Selection Proces
 	\item The application materials are then reviewed at an Evaluations meeting.
 	Then a simple majority vote, of attending members, is held on whether or not to accept the person as an Introductory Member.
 \end{enumerate}
-Note: Most membership privileges do not initiate until successful completion of the introductory process.
-This means that until the member has passed the Introductory Evaluation, the member does NOT have the right to vote on House issues and does NOT count towards quorum.
-The member does, however, have the right to use Computer Science House's facilities.
-The member is not required to pay dues during the Introductory Process.
-\\* \\*
-Additional Note: No hazing shall occur at any time during the Selection Process in accordance with the New York State Hazing Laws.
 
-% Incoming RIT students is defined as students who have attended RIT for less than 1 full semester
 \asubsubsubsection{Selection Process for Incoming RIT Students}
 \begin{enumerate}
 	\item During Spring semester, the Evaluations Director selects a group of Active Members to form a Selections Committee.
@@ -188,6 +192,7 @@ Intro members receive the right to use Computer Science House facilities, to att
 
 \asubsection{Introductory Membership Evaluations}
 \asubsection{The Introductory Process}
+\break
 The Introductory Process is designed to provide an easy means for Introductory Members to meet existing House members, learn House history, demonstrate their involvement potential to House, and allow existing House members to evaluate them for Active Membership.
 \asubsection{The Evaluation Period}
 The Process will occur either once or twice per semester, and will last for six (6) weeks.
@@ -205,17 +210,6 @@ Each Introductory Process participant, after the first week, is given two (2) we
 \end{itemize}
 At the discretion of the Evaluations Director, any Introductory Packet may be extended to accommodate extenuating circumstances.
 \asubsubsection{Expectations of an Introductory Member}
-Before the end of the Process, an Introductory Member is expected to:
-\begin{itemize}
-\item Attend all House meetings during the process
-\item Complete the Introductory Packet
-\item Attend at least one House directorship meeting for each week of the process (including permanent and Ad Hoc directorship meetings)
-\item Attend at least one House social event during the process
-\item Attend at least two seminars relating to computing or electronics
-\item Sign a copy of the Membership Agreement describing a House Member’s responsibilities and expectations
-\end{itemize}
-
-\asubsubsection{Introductory Evaluation}
 The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of Active Membership.
 It occurs at the conclusion of the final week of the Process.
 
@@ -992,10 +986,21 @@ This ruling may be appealed in the same manner as an E-Board decision \ref{Appea
 There are two methods for non-semantic change to the Constitution.
 A Maintainer may approve any proposed change that does not affect the meaning of the document.
 Alternatively, the change may be presented to the House for discussion followed by an Immediate Vote.
-A quorum of fifty percent of the Total Number of Possible Votes is required for passage.
-
-\asubsection{Semantic Changes}
-Any semantic change to the Constitution requires the change to be proposed in writing for discussion at a House Meeting.
+Any modifications made due to the discussion are added to the written proposal and the modified proposal is posted in the House during the week.
+The final proposal is presented the following week and ballots are distributed for a ballot House vote as described in \ref{Balloted Vote}.
+The ballots are collected for a minimum of a forty-eight hour period.
+A quorum of two-thirds of the Total Number of Possible Votes must cast ballots for the vote to be official.
+A vote equaling or exceeding two-thirds of the number of votes cast is required for the change to be placed into the constitution.
+The Constitution may be overridden by an immediate House vote as described in \ref{Immediate Vote}.
+There must be a quorum of eighty-five percent of the Total Number of Possible Votes for the vote to be official.
+A vote equaling or exceeding ninety percent of the number of votes cast is required for the override to take effect.
+Any modifications made due to the discussion are added to the written proposal and the modified proposal is posted in the House during the week.
+The final proposal is presented the following week and ballots are distributed for a ballot House vote as described in \ref{Balloted Vote}.
+The ballots are collected for a minimum of a forty-eight hour period.
+A quorum of two-thirds of the Total Number of Possible Votes must cast ballots for the vote to be official.
+A vote equaling or exceeding two-thirds of the number of votes cast is required for the change to be placed into the constitution.
+The Constitution may be overridden by an immediate House vote as described in \ref{Immediate Vote}.
+There must be a quorum of eighty-five percent of the Total Number of Possible Votes for the vote to be official.
 Any modifications made due to the discussion are added to the written proposal and the modified proposal is posted in the House during the week.
 The final proposal is presented the following week and ballots are distributed for a ballot House vote as described in \ref{Balloted Vote}.
 The ballots are collected for a minimum of a forty-eight hour period.

--- a/constitution.tex
+++ b/constitution.tex
@@ -206,14 +206,14 @@ At the discretion of the Evaluations Director, any Introductory Packet may be ex
 Before the end of the Process, an Introductor Member is expected to:
 \begin{itemize}
 	\item Attend all House meetings during the process
-	\item Complete the INtroductory Packet
-	\item Attend at least one House Directorship meeting for each week fo the process (including permanent and Ad Hoc directorship meetinsg)
+	\item Complete the Introductory Packet
+	\item Attend at least one House directorship meeting for each week fo the process (including permanent and Ad Hoc directorship meetings)
 	\item Attend at least one House social event during the process
 	\item Attend at least two seminars relating to computing of electronics
 	\item Sign a copy of the Membership Agreement describing a House Member's responsibilities and expectations
 \end{itemize}
 
-\asubsubsection{Introductor Evaluation}
+\asubsubsection{Introductory Evaluation}
 The Introductory Evaluation is the process by which House chooses which Introductory Members to extend an offer of Active Membership.
 It occurs at the conclusion of the final week of the Process.
 


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [x] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

removes 'note' and 'additional note' from 5.D.2.B.1 and 5.D.2.B.2, (4.A.2.A.1 and .2)

those notes are now under 4.A.2.A