### PR TITLE
5.D.2.C.1.B Clarified Membership Status During Conditional

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -630,6 +630,7 @@ A member may be given a conditional to complete as a means of making up for miss
 A conditional may be proposed by any member present at the Evaluation.
 If the conditional is approved by the Evaluations Director, it is then voted on by House.
 Each conditional consists of a set of additional requirements a deadline for completing them.
+Members who are given a conditional have their evaluation decision deferred, and therefore maintain their current membership status until the conditional is resolved.
 When the deadline expires, the conditional will be brought before the Executive Board who will assess its completeness.
 A conditional member who does not meet these additional requirements will have failed the evaluation.
 \asubsubsubsection{Appeals Process}


### PR DESCRIPTION
Check one:
- [x] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Added a sentence to clarify what the status of a member is during a conditional.
