### PR TITLE
Working on the spacing issues present in the constitution.

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -303,9 +303,13 @@ All Executive Board members are expected to attend the Semi-Annual Evaluations M
 At the beginning of any Evaluation Process listed herein, the Evaluations Director must read the sections of the Computer Science House Constitution used during the respective Evaluation Process.
 It is incumbent upon each House member to provide the Evaluation Director with whatever information they feel is necessary to ensure an accurate evaluation.
 \asubsubsubsection{Membership Evaluation}
+\hfill\break\hfill\break
 The Membership Evaluation process occurs once per academic year.
 It is performed as part of the Evaluation Process that takes place during the spring semester to comply with RIT Housing deadlines.
+\hfill\break
+%these are here to keep the spacing consistent, changing the definition of subsubsubsections fucks things over elsewhere
 \asubsubsubsubsection{Voting}
+\hfill\break\hfill\break
 Any Active Member who has completed all of the requirements as defined in \ref{Expectations of House Members} at the beginning of the Membership Evaluation passes their Membership Evaluation without being voted on or evaluated by the quorum.
 All Active Members who have not recieved an exemption from the Executive Board prior to the Membership Evaluation will be evaluated on a Member by Member basis by a quorum of Active Members.
 The Membership Evaluation shall hold members to the objective requirements defined in \ref{Expectations of House Members} and determine which members may continue as an Active Member in the following Standard Operating Session.
@@ -316,6 +320,7 @@ Neither absentee nor proxy votes are allowed.
 
 
 \asubsubsubsubsection{Outcomes}
+\hfill\break\hfill\break
 Members who pass Membership Evaluation have the option to participate as an Active Member in the following year and remain on the upcoming roster if applicable.
 \\* \\*
 If a member fails and has never passed a Membership Evaluation in the past, their membership will be revoked immediately.
@@ -330,6 +335,7 @@ Members who are given a conditional have their evaluation decision deferred, and
 When the deadline expires, the conditional will be brought before the Executive Board who will assess its completeness.
 A conditional member who does not meet these additional requirements will have failed the evaluation.
 \asubsubsubsection{Appeals Process}
+\hfill\break\hfill\break
 If a member disagrees with the outcome of any evaluation, (e.g. is not asked to return to the House for the following year) and wishes to appeal the decision, they may do so as stated in \ref{Appeals}.
 \\* \\*
 If the member is still unsatisfied after being heard by the Executive Board, the appeal may be brought to the attention of the ResLife Advisor.
@@ -602,6 +608,7 @@ However, the Chairperson and at least two-thirds of the Voting Members of the Ex
 
 \asubsection{Selection}
 \asubsubsection{Dual Directorship}
+\hfill\break\hfill\break
 Social and Research and Development are the only voting Executive Board positions that allow for Dual Directorship.
 
 If two candidates elect to run as a Dual Directorship, their names are placed together on a single line of the election ballot.
@@ -763,6 +770,7 @@ Membership is composed of all Root Type Persons.
 \end{enumerate}
 
 \asubsubsection{Creation of Accounts}
+\hfill\break\hfill\break
 Root Type Persons have the authority to manage user accounts for House systems.
 Before introductory, active, or alumni members may receive an account they must:
 \renewcommand{\theenumi}{\alph{enumi}} % For this section, we want items to use letters
@@ -773,11 +781,13 @@ Before introductory, active, or alumni members may receive an account they must:
 Accounts for honorary and advisory members may be created at the discretion of the Root Type Persons.
 
 \asubsubsection{Code of Conduct}
+\hfill\break\hfill\break
 The Code of Conduct located at \url{https://github.com/ComputerScienceHouse/CodeOfConduct} is the canonical Code of Conduct for Computer Science House accounts.
 \\* \\*
 Members are bound to the Code of Conduct revision that they sign when initially creating their account.
 Members may sign a more recent revision of the Code of Conduct to update their agreement.
 \asubsubsubsection{Changes}
+\hfill\break\hfill\break
 The following process is used for making changes to the Code of Conduct document.
 \begin{enumerate}
 	\item A Root Type Person drafts a change to the Code of Conduct and makes publicly available both the summary and difference file of the change.
@@ -797,6 +807,7 @@ The collection period of house dues will be decided in conjunction with The Cent
 During the dues collection period, dues for both semesters for all Active Members are collected through the member's RIT bill.
 Dues for any Alumni Member in good standing are to be collected when intention to pay is expressed to the Financial Director.
 \asubsubsection{Rules for Giving Exceptions and Exemptions for House Dues}
+\hfill\break\hfill\break
 If a member is unable to pay dues upon request, they may appeal their situation to the Financial Director.
 If the Financial Director deems their situation appropriate, they may grant specific extensions or reductions of the member's payment as they see fit.
 If the Financial Director deems their situation inappropriate for extension, the member may appeal to the Executive Board.
@@ -864,10 +875,12 @@ This status indicates their right to priority housing on the floor.
 Alumni Members in good standing keep the housing status they had as Active Members.
 Alumni Members in bad standing have Off-Floor status.
 \asubsubsection{On-Floor Status}
+\hfill\break\hfill\break
 Members with On-Floor status are eligible to live on the floor.
 To be granted On-Floor status, members may notify the Evaluations Director that they would like to come up for a vote.
 The Evaluations Director will then bring them up for vote at the next meeting.
 \asubsubsection{Off-Floor Status}
+\hfill\break\hfill\break
 Members with Off-Floor status do not have the right to live on the floor.
 They still have access to all other privileges associated with their membership, and may still accumulate Housing Priority Points.
 
@@ -878,13 +891,15 @@ Housing Priority Points are accumulated once per Operating Session at the conclu
 \\* \\*
 In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
 \asubsubsection{Single Room Assignments}
+\hfill\break\hfill\break
 When a single room on the House becomes available it is offered to the member who carries the highest Housing Priority as defined in \ref{Housing Priority System}.
 In the event of a tie, the members will be approached simultaneously and if they are unable to decide fairly between themselves, the assignment of priority will be made by random selection of the tied members.
 If that House member declines the option, it will be offered to the member with the next highest Housing Priority.
 This process continues until a member selects to move into the single room.
 Once in a single room, a House member retains the assignment until voluntarily giving it up.
 It should be noted that members selecting this option must agree to any additional charges applied by the Department of Residence Life for residing in a single room.
-\asubsubsection{Double Rooms as Single rooms}
+\asubsubsection{Double Rooms as Single Rooms}
+\hfill\break\hfill\break
 During the third week of each semester, if there is no waiting list for residency on the House, any vacant rooms will be offered to House members as single rooms assignments according to the method as described in \ref{Single Room Assignments}.
 It should be noted that this does not mean members will be relocated into empty spaces so that the member with top priority is offered the single.
 This only applies if there is a totally vacant room.
@@ -932,6 +947,7 @@ The Vote Counters then tally the results.
 \asubsection{Immediate Vote}
 
 \asubsubsection{Method of Vote}
+\hfill\break\hfill\break
 The Chair of the Vote will state all possible ways to vote, then call out each possibility one at a time.
 The chairing member will count the number of members casting their immediate vote for that possibility.
 Any members that count towards Quorum that do not explicitly cast a vote will have their vote counted as an Abstention.


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [ ] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):

Added line breaks to  these sections to help the spacing of the document stay consistent.

Membership Evaluation
Voting
Outcomes
Appeals Process
Dual Directorship
Creation of Accounts
Code of Conduct
Changes
rules for Giving exceptions and Exemptions for House Dues
On-Floor Status
Off-Floor Status
Single Room Assignments
Double Rooms as Single rooms -- change Single rooms to Single Rooms
Method of Vote


The screenshots below are my attempts at changing the definitions of 
 - '\asubsubsubsection'
 - '\asubsubsection'

these are not sections that needed spacing changes so. Mainly I had a skill issue and the way I know how to change the definition was not good enough so this can be changed by someone else who knows latex better. 

![Screenshot from 2024-03-29 14-03-12](https://github.com/rhochgraf21/Constitution/assets/90466377/963c35e9-36d7-4e79-95c8-7cdc4cfed603)
![Screenshot from 2024-03-29 14-02-52](https://github.com/rhochgraf21/Constitution/assets/90466377/9d60231b-bab5-4f96-bd4e-ca1a0c880b44)


