### PR TITLE
Reorganize Budget Allocation Table in 6.A.3

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -810,9 +810,9 @@ After this date, dues collection is suspended until the start of the next academ
 		\hline
 		OpComm       & 20\%
 		\\ \hline
-		R\&D         & 20\%
-		\\ \hline
 		Social       & 20\%
+		\\ \hline
+		R\&D         & 20\%
 		\\ \hline
 		IMPs         & 15\%
 		\\ \hline


### PR DESCRIPTION
Check one:
- [ ] Semantic Change: something about the meaning of the text is different
- [X] Non-semantic Change: Spelling, grammar, or formatting changes.

Summary of change(s):
Fixes the ordering in the budget allocation table in 6.A.3 by the attributes decided earlier in the year to account for abbreviations.
As a recap, they are first sorted by budget amount then length of the name used in the table, with Accumulated always as the last row.